### PR TITLE
Add Docker containerization with Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM langflowai/langflow:latest
+
+# Copy custom components
+COPY components/ /app/components/
+
+# Copy flow definitions
+COPY flows/ /app/flows/
+
+# Copy prompt templates
+COPY prompts/ /app/prompts/
+
+# Environment variables (override at runtime)
+ENV LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY}
+
+EXPOSE 7860
+
+CMD ["langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  langflow:
+    build: .
+    ports:
+      - "7860:7860"
+    env_file:
+      - .env
+    environment:
+      - LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY:-changeme}
+    volumes:
+      - langflow-data:/app/data
+    restart: unless-stopped
+
+volumes:
+  langflow-data:


### PR DESCRIPTION
## Add Docker containerization support

- Dockerfile based on langflowai/langflow:latest
- Copies custom components, flows, and prompts into container
- docker-compose.yml with env file support and persistent volume
- Exposes port 7860 for Langflow web interface