### PR TITLE
ci: Run pytest on push and pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          python-version: "3.13"
+      - run: uv sync --locked
+      - run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           enable-cache: true
           python-version: "3.13"


### PR DESCRIPTION
The repo has no CI. The only safety net is running `uv run pytest` locally, so a regression can land on `main` unnoticed. This adds a minimal GitHub Actions workflow that runs the existing suite on every push to `main` and every pull request, turning a broken change into a red check.

- Single job on `ubuntu-latest`, Python 3.13 via `astral-sh/setup-uv` with dependency caching.
- `uv sync --locked` installs from the committed `uv.lock` and fails the build if the lock is stale.
- `concurrency` cancels superseded in-progress runs; job permissions are read-only.

Linting and release automation are intentionally out of scope.

Closes #19.