### PR TITLE
feat: cost controls, checkpoints, run artifacts, and config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-06-11
+
+### Added
+
+- **Multi-provider pipeline** — Codex (`codex`) and Gemini (`gemini`) CLI providers alongside Claude, with per-phase `provider`/`model` selection in `step-by-step.toml` (#16).
+- **Configurable pipeline** — a `pipeline` array to reorder phases, drop built-ins, or add custom prompt-only phases (`kind = "simple"` with `skill` or `prompt`); per-phase `max_iterations`; fail-fast structural validation (#17).
+- **`[limits]` config section** — `provider_timeout_seconds`, `max_ram_pct`, `max_cost_usd`, `default_max_iterations`, and every context-truncation size (`prev_output_chars`, `worker_prev_output_chars`, `evaluation_output_chars`, `commit_context_chars`, `diff_stat_chars`, `feedback_chars`). Unknown keys or out-of-range values abort before the run.
+- **Cost cap** — with `max_cost_usd` set, the run stops at the next stage boundary once accumulated cost reaches the cap, and each stage's completion log line shows that stage's cost delta.
+- **`pipeline --check`** — config dry-run: validates the TOML and prints the resolved pipeline (phase, kind, provider, model, prompt source), the effective limits, and the provider preflight, without calling any LLM. Exits 0/1.
+- **`[confirm]` checkpoints** — `phases` pauses before the listed phases (Commit & PR additionally shows `git status` and `git diff --stat` so you see what will be committed); `review_tasks` opens a checkbox review of the decomposed subtasks before the parallel fan-out; `step` (or the `--step` flag) pauses after every completed stage.
+- **`[artifacts]` run persistence** — each run writes `<repo>/.step-by-step/runs/<timestamp>/` with `prompt.txt`, one `NN-<stage>.md` per stage (full output or error; gate re-runs append `-2`, `-3`…), and `run.json` stats.
+- **Internal prompt overrides** — the Decomposition prompt accepts the existing `skill`/`prompt` keys, and the quality-gate evaluator accepts `eval_prompt`/`eval_skill` on the gate phase.
+- **Per-provider autonomy flags** — `skip_permissions = false` omits `--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox` / `--yolo`, and `extra_args` appends raw CLI arguments; both in `[defaults]` or per phase.
+- **Ctrl+X** cancels the running pipeline, killing provider subprocesses and leaving every stage re-runnable.
+- **CI** — GitHub Actions runs the test suite on every push to `main` and every pull request (#21).
+
+### Changed
+
+- The provider subprocess timeout is configurable (`provider_timeout_seconds`); it was previously fixed at 600 seconds.
+- The final status distinguishes intentional stops (`⏹ Stopped` — user checkpoint or cost cap) from real failures (`✗ Failed`).
+- With no new config keys, behavior is identical to 0.1.x: every new default equals the previous hardcoded value, and confirmations/artifacts are off by default.
+
+### Fixed
+
+- Confirmation-modal bodies and task-review checkbox labels render raw LLM/git output literally; bracketed text such as `list[int]` is no longer swallowed as style markup.
+- `pyproject.toml` and `npm/package.json` versions are synced (both 0.2.0) and guarded by a test.
+
+## [0.1.2] - 2026-03-18
+
+### Fixed
+
+- npm package: include the README in the published package and correct the repository URL format.
+
+## [0.1.0] - 2026-03-13
+
+### Added
+
+- Initial release: Textual TUI running a seven-stage Claude pipeline (Planning, Decomposition, parallel Implementation and Tests & Validation, Code Quality gate, Documentation, Commit & PR) with RAM-aware worker concurrency, live streaming, per-call cost tracking, log export, and click-to-rerun stage pills.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ pipeline /path/to/your/repo
 
 # Load a prompt from a file and start immediately
 pipeline /path/to/your/repo -f prompt.txt
+
+# Validate the config and print the resolved pipeline, without running anything
+pipeline /path/to/your/repo --check
+
+# Step mode: pause after each completed stage until you confirm
+pipeline /path/to/your/repo --step
 ```
 
 **uvx (no install):**

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ Custom phases must be `kind = "simple"` — the other kinds are reserved for the
 
 The pipeline is validated before the run: an empty pipeline, duplicate names, a `parallel` phase with no preceding `decompose`, more than one `commit_pr` or `gate`, a custom phase that isn't `simple`, or one missing both `skill` and `prompt` all abort with a clear message. A `[phases.X]` table for a phase that isn't in the pipeline is ignored.
 
+### Run artifacts
+
+Set `[artifacts] enabled = true` to persist every run to disk for later inspection — the full output of each stage (not just the 300-char log preview), the original prompt, and the run stats:
+
+```toml
+[artifacts]
+enabled = true               # default: false
+dir = ".step-by-step/runs"   # relative to the target repo (default)
+```
+
+Each run writes `<repo>/.step-by-step/runs/<timestamp>/` containing `prompt.txt`, one `NN-<stage>.md` per stage (provider, model, status, elapsed, full output or error), and `run.json` (calls, cost, stage time, failed). Add `.step-by-step/runs/` to the target repo's `.gitignore`.
+
 ### Safety
 
 By default the pipeline runs every provider fully autonomous — no sandbox, no approval prompts (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex, `--yolo` for Gemini). With a multi-provider config that is up to three agents with full read/write/execute access to the target repository. Run it on a throwaway branch or an isolated clone.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Type your task in the input area at the bottom and press `Ctrl+Enter` to start.
 | `Ctrl+Enter` | Submit prompt and run the pipeline |
 | `Ctrl+L` | Clear the activity log |
 | `Ctrl+E` | Export log to `pipeline_log_<timestamp>.txt` |
+| `Ctrl+X` | Cancel the running pipeline |
 | `Ctrl+C` | Quit |
 
 ### Re-running from a specific stage

--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ Claude drives two autonomous feedback loops — it decides when to stop by repor
 
 ### RAM-based flow control
 
-Worker concurrency is not capped by a fixed number. Instead, the pipeline uses TCP-style flow control: a new worker starts only when system RAM is below 75%. Starts are serialized and include a post-start delay so the OS can register each new process's footprint before the next candidate is evaluated. When RAM is high, new workers queue up and resume as running workers release memory.
+Worker concurrency is not capped by a fixed number. Instead, the pipeline uses TCP-style flow control: a new worker starts only when system RAM is below a threshold (75% by default, configurable via `[limits].max_ram_pct`). Starts are serialized and include a post-start delay so the OS can register each new process's footprint before the next candidate is evaluated. When RAM is high, new workers queue up and resume as running workers release memory.
+
+### Cost control & checkpoints
+
+The pipeline is autonomous by default, but every expensive decision can be bounded or gated:
+
+- **Cost cap** — set `[limits] max_cost_usd` and the run stops at the next stage boundary once accumulated cost reaches it; the activity log shows each stage's cost delta. See [Limits](#limits).
+- **Checkpoints** — pause before chosen phases (with a git status + diff preview before Commit & PR), review and exclude subtasks before the parallel fan-out, or step through the whole run stage by stage. See [Confirmations](#confirmations).
+- **Config dry-run** — `pipeline --check` validates your TOML and prints the resolved pipeline without calling any LLM.
+- **Run artifacts** — persist each run's prompts, full per-stage outputs, and stats to disk for later inspection. See [Run artifacts](#run-artifacts).
+- **Cancel anytime** — `Ctrl+X` stops the run, kills provider subprocesses, and leaves every stage re-runnable.
 
 ---
 
@@ -299,7 +309,7 @@ Once a run completes, every stage pill in the header becomes clickable. Click an
 │  (live output from active    │                                  │
 │   stage or worker)           │                                  │
 ├──────────────────────────────┴──────────────────────────────────┤
-│  ^p palette  ^l Clear Log  ctrl+↵ Run  ^e Export Log  ^m Monitor        Calls: 4  |  Cost: $0.0234  |  Time: 1m 20s  │
+│  ^p palette  ^l Clear Log  ctrl+↵ Run  ^e Export Log  ^m Monitor  ^x Cancel        Calls: 4  |  Cost: $0.0234  |  Time: 1m 20s  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -310,23 +320,38 @@ Once a run completes, every stage pill in the header becomes clickable. Click an
 ```
 app/
 ├── __main__.py      Entry point
-├── models.py        Shared data classes (Task, WorkerResult, PipelineStats)
-├── agents.py        Claude CLI invocation, flow control, and worker coordination
-├── stages.py        Stage definitions, prompt templates, and pipeline configuration
+├── tui.py           PipelineApp (Textual App), CLI flags (--check, --step), main()
+├── runner.py        PipelineRunnerMixin: dispatch loop, reruns, checkpoints, cost cap
 ├── pipeline.py      Stage runners: run_stage() and run_stage_parallel()
-├── runner.py        PipelineRunnerMixin: run_pipeline() and rerun_from_stage()
-├── widgets.py       StagePill TUI widget and display constants
+├── stages.py        Stage dataclass and the built-in stage registry
+├── agents.py        Decomposition manager agent
+├── evaluation.py    Quality-gate evaluator
+├── workers.py       Parallel workers and RAM-aware concurrency control
 ├── git.py           Git/gh subprocess helpers and Commit & PR stage runner
-└── tui.py           PipelineApp (Textual App) and main() entry point
+├── config.py        TOML config: providers, pipeline, [limits], [confirm], [artifacts]
+├── skills.py        SKILL.md resolution and prompt-token rendering
+├── prompts.py       Stage and internal-agent prompt templates
+├── check.py         `pipeline --check` config dry-run
+├── confirm.py       Confirmation and subtask-review modals
+├── artifacts.py     Per-run artifacts under .step-by-step/runs/
+├── models.py        Shared data classes (Task, WorkerResult, PipelineStats)
+├── widgets.py       StagePill and SystemMonitor TUI widgets
+└── providers/       claude / codex / gemini CLI adapters
 ```
 
 ---
 
 ## Safety
 
-The pipeline invokes `claude --dangerously-skip-permissions` so agents can read and write files autonomously. **Only point it at repositories where you trust the output.** Always review the diff before the PR stage commits.
+By default the pipeline invokes each provider with its autonomy flag (e.g. `claude --dangerously-skip-permissions`) so agents can read and write files unattended — this is configurable per provider via `skip_permissions` (see [Safety](#safety) under Configuration). **Only point it at repositories where you trust the output.** Review the diff before the PR stage commits, or enable a `[confirm]` checkpoint on `Commit & PR` to see it in-app.
 
-Each subprocess is run with a 10-minute timeout and cleaned up unconditionally on exit — even on errors or cancellation — so stalled Claude processes do not accumulate.
+Each subprocess runs with a timeout (10 minutes by default, `[limits].provider_timeout_seconds`) and is cleaned up unconditionally on exit — even on errors or cancellation — so stalled provider processes do not accumulate.
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,20 @@ The pipeline is validated before the run: an empty pipeline, duplicate names, a 
 
 ### Safety
 
-The pipeline runs every provider fully autonomous — no sandbox, no approval prompts (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex, `--yolo` for Gemini). With a multi-provider config that is up to three agents with full read/write/execute access to the target repository. Run it on a throwaway branch or an isolated clone.
+By default the pipeline runs every provider fully autonomous — no sandbox, no approval prompts (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex, `--yolo` for Gemini). With a multi-provider config that is up to three agents with full read/write/execute access to the target repository. Run it on a throwaway branch or an isolated clone.
+
+Both behaviors are configurable, in `[defaults]` or per phase (the phase table wins):
+
+```toml
+[defaults]
+skip_permissions = false   # omit the autonomy flag: the CLI runs in its own approval/sandbox mode
+extra_args = []            # raw arguments appended to the provider command
+
+[phases.Implementation]
+skip_permissions = true    # this phase keeps full autonomy
+```
+
+With `skip_permissions = false` the provider CLI falls back to its own approval or sandbox mode. The pipeline runs non-interactively, so there is no terminal to approve actions on — a supervised run may be unable to edit files. Defaults are unchanged: without these keys, every provider runs fully autonomous as before.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ enabled = true               # default: false
 dir = ".step-by-step/runs"   # relative to the target repo (default)
 ```
 
-Each run writes `<repo>/.step-by-step/runs/<timestamp>/` containing `prompt.txt`, one `NN-<stage>.md` per stage (provider, model, status, elapsed, full output or error), and `run.json` (calls, cost, stage time, failed). Add `.step-by-step/runs/` to the target repo's `.gitignore`.
+Each run writes `<repo>/.step-by-step/runs/<timestamp>/` containing `prompt.txt`, one `NN-<stage>.md` per stage (provider, model, status, elapsed, full output or error; gate re-runs of a stage append `-2`, `-3`…), and `run.json` (calls, cost, stage time, failed). Add `.step-by-step/runs/` to the target repo's `.gitignore`.
 
 ### Safety
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ enabled = true               # default: false
 dir = ".step-by-step/runs"   # relative to the target repo (default)
 ```
 
-Each run writes `<repo>/.step-by-step/runs/<timestamp>/` containing `prompt.txt`, one `NN-<stage>.md` per stage (provider, model, status, elapsed, full output or error; gate re-runs of a stage append `-2`, `-3`…), and `run.json` (calls, cost, stage time, failed). Add `.step-by-step/runs/` to the target repo's `.gitignore`.
+Each run writes `<repo>/.step-by-step/runs/<timestamp>/` containing `prompt.txt`, one `NN-<stage>.md` per stage (provider, model, status, elapsed, full output or error; gate re-runs of a stage append `-2`, `-3`…), and `run.json` (calls, cost, stage time, outcome: completed/failed/stopped). Add `.step-by-step/runs/` to the target repo's `.gitignore`.
 
 ### Safety
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,79 @@ Custom phases must be `kind = "simple"` — the other kinds are reserved for the
 
 The pipeline is validated before the run: an empty pipeline, duplicate names, a `parallel` phase with no preceding `decompose`, more than one `commit_pr` or `gate`, a custom phase that isn't `simple`, or one missing both `skill` and `prompt` all abort with a clear message. A `[phases.X]` table for a phase that isn't in the pipeline is ignored.
 
+### Limits
+
+All runtime limits live in an optional `[limits]` table. Defaults match the values the pipeline always used; unknown keys or out-of-range values abort before the run with a clear message:
+
+```toml
+[limits]
+provider_timeout_seconds = 600   # per provider subprocess call
+max_ram_pct = 75.0               # worker fan-out RAM threshold
+max_cost_usd = 5.0               # absent = no cap
+default_max_iterations = 3       # gate re-run cap (a phase's max_iterations wins)
+prev_output_chars = 8000         # context passed to single-agent stages
+worker_prev_output_chars = 6000  # context passed to each parallel worker
+evaluation_output_chars = 4000   # stage output shown to the quality-gate evaluator
+commit_context_chars = 3000      # context for the commit/PR generator
+diff_stat_chars = 1500           # diff stat shown to the commit/PR generator
+feedback_chars = 3000            # gate feedback injected into the re-run
+```
+
+When `max_cost_usd` is set, accumulated cost is checked at every stage boundary and before each gate loop-back; the run stops with "Cost cap reached" once it is hit. A parallel fan-out can overshoot the cap before the next boundary check — the cap bounds stage starts, not in-flight workers. Each stage's completion line in the activity log shows that stage's cost delta.
+
+### Confirmations
+
+The `[confirm]` table adds user checkpoints to an otherwise fully autonomous run:
+
+```toml
+[confirm]
+phases = ["Commit & PR"]   # pause before these phases; Commit & PR shows git status + diff stat
+review_tasks = true        # review/exclude subtasks after Decomposition, before the worker fan-out
+step = false               # pause after every completed stage (same as the --step flag)
+```
+
+Cancelling at any checkpoint stops the run. Stage pills stay clickable, so you can resume from the stopped phase.
+
+### Overriding the internal prompts
+
+Besides the per-stage `skill`/`prompt` overrides, the two internal agents accept custom prompts:
+
+- **Decomposition** — `skill`/`prompt` on `[phases.Decomposition]`. The template receives `{prompt}` (the task) and `{prev_output}` (the plan) and must keep the JSON-array output contract (`id`, `description`, `files`); non-JSON output falls back to a single subtask.
+- **Quality-gate evaluator** — `eval_prompt` or `eval_skill` (exactly one, only on the gate phase). The template receives the stage output as `{prev_output}` and must answer only `yes` (iterate) or `no` (proceed).
+
+```toml
+[phases."Code Quality"]
+eval_prompt = "Does this output contain blocking bugs? Answer only yes or no.\n\n{prev_output}"
+```
+
+### Full example
+
+```toml
+pipeline = ["Planning", "Decomposition", "Implementation", "Tests & Validation", "Code Quality", "Commit & PR"]
+
+[defaults]
+provider = "claude"
+model = ""
+skip_permissions = true
+
+[limits]
+provider_timeout_seconds = 900
+max_cost_usd = 10.0
+
+[confirm]
+phases = ["Commit & PR"]
+review_tasks = true
+
+[artifacts]
+enabled = true
+
+[phases."Code Quality"]
+provider = "codex"
+model = "gpt-5.1-codex"
+max_iterations = 2
+eval_prompt = "Real blocking issues? Answer only yes or no.\n\n{prev_output}"
+```
+
 ### Run artifacts
 
 Set `[artifacts] enabled = true` to persist every run to disk for later inspection — the full output of each stage (not just the 300-char log preview), the original prompt, and the run stats:

--- a/app/agents.py
+++ b/app/agents.py
@@ -3,26 +3,19 @@
 import json
 
 from app.models import Task
+from app.prompts import DECOMPOSITION
+from app.skills import render_prompt
 
 
-async def decompose_task(prompt: str, plan: str, working_dir: str, provider) -> list[Task]:
-    """Manager agent: decompose a plan into independent parallel subtasks."""
-    decompose_prompt = (
-        "You are a task decomposition agent. Given a plan, break it into independent subtasks "
-        "that can be worked on IN PARALLEL by different engineers.\n\n"
-        f"ORIGINAL TASK: {prompt}\n\n"
-        f"PLAN:\n{plan}\n\n"
-        "Output a JSON array of subtasks. Each subtask should have:\n"
-        '- "id": sequential integer starting at 1\n'
-        '- "description": what to implement (be specific and self-contained, include enough context)\n'
-        '- "files": list of files this subtask will create or modify\n\n'
-        "Rules:\n"
-        "- Each subtask must be independent enough to work on in parallel\n"
-        "- Include enough context in each description so a worker can act without seeing other subtasks\n"
-        "- Create as many subtasks as the complexity genuinely requires — no artificial limit\n"
-        "- If the task is simple and cannot be split, return a single subtask\n"
-        "- Output ONLY the JSON array, no markdown fences or other text\n"
-    )
+async def decompose_task(
+    prompt: str, plan: str, working_dir: str, provider, template: str = ""
+) -> list[Task]:
+    """Manager agent: decompose a plan into independent parallel subtasks.
+
+    ``template`` overrides the built-in prompt (config ``skill``/``prompt`` keys
+    on the decompose phase); it must keep the JSON-array output contract.
+    """
+    decompose_prompt = render_prompt(template or DECOMPOSITION, prompt, plan)
 
     result = await provider.run(decompose_prompt, working_dir)
     if not result.success:

--- a/app/artifacts.py
+++ b/app/artifacts.py
@@ -38,7 +38,12 @@ class RunArtifacts:
         return cls(run_dir)
 
     def record_stage(self, index: int, stage: Stage) -> None:
-        filename = f"{index + 1:02d}-{_slugify(stage.name)}.md"
+        base_name = f"{index + 1:02d}-{_slugify(stage.name)}"
+        path = self.run_dir / f"{base_name}.md"
+        attempt = 2
+        while path.exists():
+            path = self.run_dir / f"{base_name}-{attempt}.md"
+            attempt += 1
         header = (
             f"# {stage.name}\n\n"
             f"- provider: {stage.provider_name}\n"
@@ -47,7 +52,7 @@ class RunArtifacts:
             f"- elapsed: {stage.elapsed:.1f}s\n\n"
         )
         body = stage.output or stage.error or ""
-        (self.run_dir / filename).write_text(header + body)
+        path.write_text(header + body)
 
     def finish(self, stats: PipelineStats, failed: bool) -> None:
         payload = {

--- a/app/artifacts.py
+++ b/app/artifacts.py
@@ -1,0 +1,60 @@
+"""Persistent per-run artifacts: prompt, full stage outputs, and run stats."""
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+from app.models import PipelineStats
+from app.stages import Stage
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "stage"
+
+
+class RunArtifacts:
+    """Writes one directory per pipeline run under ``<repo>/<base_dir>/``."""
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+
+    @classmethod
+    def start(cls, repo_dir: str, base_dir: str, prompt: str) -> "RunArtifacts":
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base = Path(repo_dir) / base_dir
+        base.mkdir(parents=True, exist_ok=True)
+        run_dir = base / timestamp
+        suffix = 2
+        while True:
+            try:
+                run_dir.mkdir(exist_ok=False)
+                break
+            except FileExistsError:
+                run_dir = base / f"{timestamp}-{suffix}"
+                suffix += 1
+        (run_dir / "prompt.txt").write_text(prompt)
+        return cls(run_dir)
+
+    def record_stage(self, index: int, stage: Stage) -> None:
+        filename = f"{index + 1:02d}-{_slugify(stage.name)}.md"
+        header = (
+            f"# {stage.name}\n\n"
+            f"- provider: {stage.provider_name}\n"
+            f"- model: {stage.model or '(default)'}\n"
+            f"- status: {stage.status.value}\n"
+            f"- elapsed: {stage.elapsed:.1f}s\n\n"
+        )
+        body = stage.output or stage.error or ""
+        (self.run_dir / filename).write_text(header + body)
+
+    def finish(self, stats: PipelineStats, failed: bool) -> None:
+        payload = {
+            "total_calls": stats.total_calls,
+            "total_cost_usd": stats.total_cost_usd,
+            "calls_without_cost": stats.calls_without_cost,
+            "total_stage_time": stats.total_stage_time,
+            "failed": failed,
+        }
+        (self.run_dir / "run.json").write_text(json.dumps(payload, indent=2))

--- a/app/artifacts.py
+++ b/app/artifacts.py
@@ -54,12 +54,12 @@ class RunArtifacts:
         body = stage.output or stage.error or ""
         path.write_text(header + body)
 
-    def finish(self, stats: PipelineStats, failed: bool) -> None:
+    def finish(self, stats: PipelineStats, outcome: str) -> None:
         payload = {
             "total_calls": stats.total_calls,
             "total_cost_usd": stats.total_cost_usd,
             "calls_without_cost": stats.calls_without_cost,
             "total_stage_time": stats.total_stage_time,
-            "failed": failed,
+            "outcome": outcome,
         }
         (self.run_dir / "run.json").write_text(json.dumps(payload, indent=2))

--- a/app/check.py
+++ b/app/check.py
@@ -1,0 +1,61 @@
+"""Config dry-run: validate and print the resolved pipeline without any LLM call."""
+
+from dataclasses import asdict
+
+from app.config import (
+    find_config_path,
+    load_config,
+    preflight,
+    resolve_limits,
+    resolve_pipeline,
+)
+
+
+def run_check(repo_dir: str, config_path: str = "") -> int:
+    """Print config source, resolved pipeline, limits, and preflight results.
+
+    Returns 0 on a valid config (even with missing provider CLIs, which are
+    reported), 1 on a validation error.
+    """
+    source = find_config_path(repo_dir, config_path)
+    print(f"Config: {source if source is not None else 'built-in default'}")
+
+    try:
+        config = load_config(repo_dir, config_path)
+        stages = resolve_pipeline(config, repo_dir)
+        limits = resolve_limits(config)
+    except ValueError as error:
+        print(f"Config error: {error}")
+        return 1
+
+    phases = config.get("phases", {})
+    print("\nPipeline:")
+    for stage in stages:
+        entry = phases.get(stage.name, {})
+        if "skill" in entry:
+            prompt_source = f"skill:{entry['skill']}"
+        elif "prompt" in entry:
+            prompt_source = "inline"
+        else:
+            prompt_source = "builtin"
+        gate_info = (
+            f"  max_iterations={stage.max_iterations}" if stage.kind == "gate" else ""
+        )
+        model = stage.model or "(default)"
+        print(
+            f"  {stage.name}  kind={stage.kind}  provider={stage.provider_name}  "
+            f"model={model}  prompt={prompt_source}{gate_info}"
+        )
+
+    print("\nLimits:")
+    for field_name, value in asdict(limits).items():
+        print(f"  {field_name} = {value}")
+
+    missing = preflight({stage.name: (stage.provider, stage.model) for stage in stages})
+    if missing:
+        print("\nPreflight:")
+        for message in missing:
+            print(f"  ✗ {message}")
+    else:
+        print("\nPreflight: all provider CLIs found")
+    return 0

--- a/app/config.py
+++ b/app/config.py
@@ -203,11 +203,18 @@ def resolve_pipeline(config: dict, repo_dir: str) -> list[Stage]:
         elif "prompt" in entry:
             prompt_template = entry["prompt"]
 
+        eval_prompt_template = ""
+        if "eval_skill" in entry:
+            eval_prompt_template = load_skill(entry["eval_skill"], repo_dir)
+        elif "eval_prompt" in entry:
+            eval_prompt_template = entry["eval_prompt"]
+
         stages.append(
             Stage(
                 name=name,
                 prompt_template=prompt_template,
                 worker_prompt_template=worker_prompt_template,
+                eval_prompt_template=eval_prompt_template,
                 iterable=iterable,
                 parallel=parallel,
                 provider=provider,
@@ -261,6 +268,17 @@ def _validate_pipeline(
         if has_skill and has_prompt:
             raise ValueError(
                 f"Phase '{stage.name}' declares both 'skill' and 'prompt'; declare exactly one."
+            )
+        has_eval_skill = "eval_skill" in entry
+        has_eval_prompt = "eval_prompt" in entry
+        if has_eval_skill and has_eval_prompt:
+            raise ValueError(
+                f"Phase '{stage.name}' declares both 'eval_skill' and 'eval_prompt'; declare exactly one."
+            )
+        if (has_eval_skill or has_eval_prompt) and stage.kind != "gate":
+            raise ValueError(
+                f"Phase '{stage.name}' declares an evaluation prompt but is kind "
+                f"'{stage.kind}'; only 'gate' phases use one."
             )
         if stage.name not in registry:  # custom phase
             if stage.kind != "simple":

--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,45 @@ class Limits:
 
 
 @dataclass(frozen=True)
+class Confirm:
+    phases: tuple[str, ...] = ()
+    review_tasks: bool = False
+    step: bool = False
+
+
+def resolve_confirm(config: dict, stage_names: list[str]) -> Confirm:
+    """Build :class:`Confirm` from the optional ``[confirm]`` section.
+
+    ``phases`` entries must name phases present in the resolved pipeline.
+    """
+    section = config.get("confirm", {})
+    valid_keys = [field.name for field in fields(Confirm)]
+    unknown = sorted(set(section) - set(valid_keys))
+    if unknown:
+        raise ValueError(
+            f"Unknown key(s) in [confirm]: {', '.join(unknown)}. "
+            f"Valid keys: {', '.join(valid_keys)}"
+        )
+    phases = section.get("phases", [])
+    if not isinstance(phases, list) or not all(isinstance(name, str) for name in phases):
+        raise ValueError(f"[confirm] phases must be a list of strings, got {phases!r}")
+    unknown_phases = sorted(set(phases) - set(stage_names))
+    if unknown_phases:
+        raise ValueError(
+            f"[confirm] phases name(s) not in the pipeline: {', '.join(unknown_phases)}. "
+            f"Valid phases: {', '.join(stage_names)}"
+        )
+    for key in ("review_tasks", "step"):
+        if not isinstance(section.get(key, False), bool):
+            raise ValueError(f"[confirm] {key} must be a boolean, got {section[key]!r}")
+    return Confirm(
+        phases=tuple(phases),
+        review_tasks=section.get("review_tasks", False),
+        step=section.get("step", False),
+    )
+
+
+@dataclass(frozen=True)
 class Artifacts:
     enabled: bool = False
     dir: str = ".step-by-step/runs"

--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,31 @@ class Limits:
     feedback_chars: int = 3000
 
 
+@dataclass(frozen=True)
+class Artifacts:
+    enabled: bool = False
+    dir: str = ".step-by-step/runs"
+
+
+def resolve_artifacts(config: dict) -> Artifacts:
+    """Build :class:`Artifacts` from the optional ``[artifacts]`` section."""
+    section = config.get("artifacts", {})
+    valid_keys = [field.name for field in fields(Artifacts)]
+    unknown = sorted(set(section) - set(valid_keys))
+    if unknown:
+        raise ValueError(
+            f"Unknown key(s) in [artifacts]: {', '.join(unknown)}. "
+            f"Valid keys: {', '.join(valid_keys)}"
+        )
+    enabled = section.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError(f"[artifacts] enabled must be a boolean, got {enabled!r}")
+    directory = section.get("dir", Artifacts.dir)
+    if not isinstance(directory, str) or not directory:
+        raise ValueError(f"[artifacts] dir must be a non-empty string, got {directory!r}")
+    return Artifacts(enabled=enabled, dir=directory)
+
+
 _FLOAT_LIMIT_KEYS = {"max_ram_pct", "max_cost_usd"}
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -140,8 +140,8 @@ def _user_config_path() -> Path:
     return Path(base) / "step-by-step" / "config.toml"
 
 
-def load_config(repo_dir: str, explicit_path: str | None = None) -> dict:
-    """Return the first existing config in precedence order, else the default."""
+def find_config_path(repo_dir: str, explicit_path: str | None = None) -> Path | None:
+    """Return the first existing config file in precedence order, or ``None``."""
     candidates: list[Path] = []
     if explicit_path:
         candidates.append(Path(explicit_path))
@@ -149,9 +149,17 @@ def load_config(repo_dir: str, explicit_path: str | None = None) -> dict:
     candidates.append(_user_config_path())
     for path in candidates:
         if path.is_file():
-            with open(path, "rb") as handle:
-                return tomllib.load(handle)
-    return {"defaults": dict(_DEFAULT_CONFIG["defaults"])}
+            return path
+    return None
+
+
+def load_config(repo_dir: str, explicit_path: str | None = None) -> dict:
+    """Return the first existing config in precedence order, else the default."""
+    path = find_config_path(repo_dir, explicit_path)
+    if path is None:
+        return {"defaults": dict(_DEFAULT_CONFIG["defaults"])}
+    with open(path, "rb") as handle:
+        return tomllib.load(handle)
 
 
 def resolve_providers(

--- a/app/config.py
+++ b/app/config.py
@@ -93,13 +93,46 @@ def resolve_limits(config: dict) -> Limits:
     return Limits(**resolved)
 
 
-def provider_for(name: str, model: str, timeout_seconds: int = 600) -> LLMProvider:
+def provider_for(
+    name: str,
+    model: str,
+    timeout_seconds: int = 600,
+    skip_permissions: bool = True,
+    extra_args: tuple[str, ...] = (),
+) -> LLMProvider:
     """Build the provider for ``name``, or raise ``ValueError`` if unknown."""
     cls = _PROVIDERS.get(name)
     if cls is None:
         valid = ", ".join(sorted(_PROVIDERS))
         raise ValueError(f"Unknown provider '{name}'. Valid providers: {valid}")
-    return cls(model, timeout_seconds=timeout_seconds)
+    return cls(
+        model,
+        timeout_seconds=timeout_seconds,
+        skip_permissions=skip_permissions,
+        extra_args=extra_args,
+    )
+
+
+def _provider_flags(
+    table: dict,
+    context: str,
+    fallback_skip_permissions: bool = True,
+    fallback_extra_args: tuple[str, ...] = (),
+) -> tuple[bool, tuple[str, ...]]:
+    """Read and validate ``skip_permissions``/``extra_args`` from a config table."""
+    skip_permissions = table.get("skip_permissions", fallback_skip_permissions)
+    if not isinstance(skip_permissions, bool):
+        raise ValueError(
+            f"{context}: skip_permissions must be a boolean, got {skip_permissions!r}"
+        )
+    extra_args = table.get("extra_args", list(fallback_extra_args))
+    if not isinstance(extra_args, list) or not all(
+        isinstance(argument, str) for argument in extra_args
+    ):
+        raise ValueError(
+            f"{context}: extra_args must be a list of strings, got {extra_args!r}"
+        )
+    return skip_permissions, tuple(extra_args)
 
 
 def _user_config_path() -> Path:
@@ -130,6 +163,7 @@ def resolve_providers(
     default_model = defaults.get("model", "")
     provider_for(default_provider, default_model)  # validate the default eagerly
     limits = resolve_limits(config)
+    default_skip_permissions, default_extra_args = _provider_flags(defaults, "[defaults]")
 
     phases = config.get("phases", {})
     valid = set(phase_names)
@@ -145,8 +179,20 @@ def resolve_providers(
         entry = phases.get(phase_name, {})
         name = entry.get("provider", default_provider)
         model = entry.get("model", default_model)
+        skip_permissions, extra_args = _provider_flags(
+            entry,
+            f"Phase '{phase_name}'",
+            fallback_skip_permissions=default_skip_permissions,
+            fallback_extra_args=default_extra_args,
+        )
         resolved[phase_name] = (
-            provider_for(name, model, timeout_seconds=limits.provider_timeout_seconds),
+            provider_for(
+                name,
+                model,
+                timeout_seconds=limits.provider_timeout_seconds,
+                skip_permissions=skip_permissions,
+                extra_args=extra_args,
+            ),
             model,
         )
     return resolved
@@ -168,6 +214,7 @@ def resolve_pipeline(config: dict, repo_dir: str) -> list[Stage]:
     provider_for(default_provider, default_model)  # validate the default eagerly
 
     limits = resolve_limits(config)
+    default_skip_permissions, default_extra_args = _provider_flags(defaults, "[defaults]")
     phases = config.get("phases", {})
     registry = {stage.name: stage for stage in STAGES}
     if "pipeline" in config:
@@ -180,8 +227,18 @@ def resolve_pipeline(config: dict, repo_dir: str) -> list[Stage]:
         entry = phases.get(name, {})
         provider_name = entry.get("provider", default_provider)
         model = entry.get("model", default_model)
+        skip_permissions, extra_args = _provider_flags(
+            entry,
+            f"Phase '{name}'",
+            fallback_skip_permissions=default_skip_permissions,
+            fallback_extra_args=default_extra_args,
+        )
         provider = provider_for(
-            provider_name, model, timeout_seconds=limits.provider_timeout_seconds
+            provider_name,
+            model,
+            timeout_seconds=limits.provider_timeout_seconds,
+            skip_permissions=skip_permissions,
+            extra_args=extra_args,
         )
 
         builtin = registry.get(name)

--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,7 @@ Precedence (first existing wins):
 import os
 import shutil
 import tomllib
+from dataclasses import dataclass, fields
 from pathlib import Path
 
 from app.providers.base import LLMProvider
@@ -34,6 +35,62 @@ _INSTALL_HINTS = {
 }
 
 _DEFAULT_CONFIG = {"defaults": {"provider": "claude", "model": ""}}
+
+
+@dataclass(frozen=True)
+class Limits:
+    provider_timeout_seconds: int = 600
+    max_ram_pct: float = 75.0
+    max_cost_usd: float | None = None
+    default_max_iterations: int = 3
+    prev_output_chars: int = 8000
+    worker_prev_output_chars: int = 6000
+    evaluation_output_chars: int = 4000
+    commit_context_chars: int = 3000
+    diff_stat_chars: int = 1500
+    feedback_chars: int = 3000
+
+
+_FLOAT_LIMIT_KEYS = {"max_ram_pct", "max_cost_usd"}
+
+
+def _is_positive_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value > 0
+    )
+
+
+def resolve_limits(config: dict) -> Limits:
+    """Build :class:`Limits` from the optional ``[limits]`` section.
+
+    Unknown keys and out-of-range values fail fast so a typo never silently
+    falls back to a default.
+    """
+    section = config.get("limits", {})
+    valid_keys = [field.name for field in fields(Limits)]
+    unknown = sorted(set(section) - set(valid_keys))
+    if unknown:
+        raise ValueError(
+            f"Unknown key(s) in [limits]: {', '.join(unknown)}. "
+            f"Valid keys: {', '.join(valid_keys)}"
+        )
+
+    resolved: dict = {}
+    for key, value in section.items():
+        if key in _FLOAT_LIMIT_KEYS:
+            if not _is_positive_number(value) or (key == "max_ram_pct" and value > 100):
+                expected = "a number in (0, 100]" if key == "max_ram_pct" else "a positive number"
+                raise ValueError(f"[limits] {key} must be {expected}, got {value!r}")
+            resolved[key] = float(value)
+        else:
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(
+                    f"[limits] {key} must be a positive integer, got {value!r}"
+                )
+            resolved[key] = value
+    return Limits(**resolved)
 
 
 def provider_for(name: str, model: str) -> LLMProvider:
@@ -106,6 +163,7 @@ def resolve_pipeline(config: dict, repo_dir: str) -> list[Stage]:
     default_model = defaults.get("model", "")
     provider_for(default_provider, default_model)  # validate the default eagerly
 
+    limits = resolve_limits(config)
     phases = config.get("phases", {})
     registry = {stage.name: stage for stage in STAGES}
     if "pipeline" in config:
@@ -150,7 +208,7 @@ def resolve_pipeline(config: dict, repo_dir: str) -> list[Stage]:
                 provider_name=provider.name,
                 model=model,
                 kind=kind,
-                max_iterations=entry.get("max_iterations", 3),
+                max_iterations=entry.get("max_iterations", limits.default_max_iterations),
             )
         )
 

--- a/app/config.py
+++ b/app/config.py
@@ -93,13 +93,13 @@ def resolve_limits(config: dict) -> Limits:
     return Limits(**resolved)
 
 
-def provider_for(name: str, model: str) -> LLMProvider:
+def provider_for(name: str, model: str, timeout_seconds: int = 600) -> LLMProvider:
     """Build the provider for ``name``, or raise ``ValueError`` if unknown."""
     cls = _PROVIDERS.get(name)
     if cls is None:
         valid = ", ".join(sorted(_PROVIDERS))
         raise ValueError(f"Unknown provider '{name}'. Valid providers: {valid}")
-    return cls(model)
+    return cls(model, timeout_seconds=timeout_seconds)
 
 
 def _user_config_path() -> Path:
@@ -129,6 +129,7 @@ def resolve_providers(
     default_provider = defaults.get("provider", "claude")
     default_model = defaults.get("model", "")
     provider_for(default_provider, default_model)  # validate the default eagerly
+    limits = resolve_limits(config)
 
     phases = config.get("phases", {})
     valid = set(phase_names)
@@ -144,7 +145,10 @@ def resolve_providers(
         entry = phases.get(phase_name, {})
         name = entry.get("provider", default_provider)
         model = entry.get("model", default_model)
-        resolved[phase_name] = (provider_for(name, model), model)
+        resolved[phase_name] = (
+            provider_for(name, model, timeout_seconds=limits.provider_timeout_seconds),
+            model,
+        )
     return resolved
 
 
@@ -176,7 +180,9 @@ def resolve_pipeline(config: dict, repo_dir: str) -> list[Stage]:
         entry = phases.get(name, {})
         provider_name = entry.get("provider", default_provider)
         model = entry.get("model", default_model)
-        provider = provider_for(provider_name, model)
+        provider = provider_for(
+            provider_name, model, timeout_seconds=limits.provider_timeout_seconds
+        )
 
         builtin = registry.get(name)
         if builtin is not None:

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -1,0 +1,39 @@
+"""Modal confirmation screens for pipeline checkpoints."""
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+
+class ConfirmScreen(ModalScreen[bool]):
+    """Scrollable confirmation dialog resolving to True (continue) or False (cancel)."""
+
+    BINDINGS = [
+        Binding("enter", "confirm", "Continue"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, title: str, body: str) -> None:
+        super().__init__()
+        self._title = title
+        self._body = body
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-panel"):
+            yield Label(self._title, id="confirm-title")
+            with VerticalScroll(id="confirm-body-scroll"):
+                yield Static(self._body, id="confirm-body")
+            with Horizontal(id="confirm-buttons"):
+                yield Button("Continue", variant="primary", id="confirm-continue")
+                yield Button("Cancel", variant="error", id="confirm-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm-continue")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -1,5 +1,6 @@
 """Modal confirmation screens for pipeline checkpoints."""
 
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -26,7 +27,9 @@ class ConfirmScreen(ModalScreen[bool]):
         with Vertical(id="confirm-panel"):
             yield Label(self._title, id="confirm-title")
             with VerticalScroll(id="confirm-body-scroll"):
-                yield Static(self._body, id="confirm-body")
+                # markup=False: bodies carry raw LLM/git output where brackets
+                # (e.g. ``list[int]``) must render literally, not as style tags.
+                yield Static(self._body, id="confirm-body", markup=False)
             with Horizontal(id="confirm-buttons"):
                 yield Button("Continue", variant="primary", id="confirm-continue")
                 yield Button("Cancel", variant="error", id="confirm-cancel")
@@ -64,8 +67,10 @@ class TaskReviewScreen(ModalScreen[list[int] | None]):
             with VerticalScroll(id="task-review-scroll"):
                 for task in self._tasks:
                     files = ", ".join(task.files) if task.files else "—"
+                    # rich.Text label: task descriptions carry raw LLM output
+                    # where brackets must render literally, not as style tags.
                     yield Checkbox(
-                        f"#{task.id} {task.description} ({files})",
+                        Text(f"#{task.id} {task.description} ({files})"),
                         value=True,
                         id=f"task-checkbox-{task.id}",
                     )

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -4,7 +4,9 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static
+from textual.widgets import Button, Checkbox, Label, Static
+
+from app.models import Task
 
 
 class ConfirmScreen(ModalScreen[bool]):
@@ -37,3 +39,55 @@ class ConfirmScreen(ModalScreen[bool]):
 
     def action_cancel(self) -> None:
         self.dismiss(False)
+
+
+class TaskReviewScreen(ModalScreen[list[int] | None]):
+    """Checkbox review of decomposed subtasks.
+
+    Resolves to the selected task ids (Continue) or ``None`` (Cancel).
+    """
+
+    BINDINGS = [
+        Binding("enter", "confirm", "Continue"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, tasks: list[Task]) -> None:
+        super().__init__()
+        self._tasks = tasks
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="task-review-panel"):
+            yield Label(
+                "Review subtasks before the parallel fan-out", id="task-review-title"
+            )
+            with VerticalScroll(id="task-review-scroll"):
+                for task in self._tasks:
+                    files = ", ".join(task.files) if task.files else "—"
+                    yield Checkbox(
+                        f"#{task.id} {task.description} ({files})",
+                        value=True,
+                        id=f"task-checkbox-{task.id}",
+                    )
+            with Horizontal(id="task-review-buttons"):
+                yield Button("Continue", variant="primary", id="task-review-continue")
+                yield Button("Cancel", variant="error", id="task-review-cancel")
+
+    def _selected_ids(self) -> list[int]:
+        return [
+            task.id
+            for task in self._tasks
+            if self.query_one(f"#task-checkbox-{task.id}", Checkbox).value
+        ]
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "task-review-continue":
+            self.dismiss(self._selected_ids())
+        else:
+            self.dismiss(None)
+
+    def action_confirm(self) -> None:
+        self.dismiss(self._selected_ids())
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -1,8 +1,10 @@
 """Quality-gate evaluator: decide whether a stage needs another iteration."""
 
+from app.config import Limits
+
 
 async def evaluate_should_iterate(
-    stage_output: str, working_dir: str, provider
+    stage_output: str, working_dir: str, provider, limits: Limits = Limits()
 ) -> bool:
     """Ask the given provider whether the stage output has blocking issues."""
     prompt = (
@@ -10,7 +12,7 @@ async def evaluate_should_iterate(
         "whether it contains genuine issues that require another implementation iteration.\n\n"
         "Answer ONLY with 'yes' if there are real issues that need fixing, "
         "or 'no' if the output is satisfactory and the pipeline can proceed.\n\n"
-        f"STAGE OUTPUT:\n{stage_output[:4000]}"
+        f"STAGE OUTPUT:\n{stage_output[: limits.evaluation_output_chars]}"
     )
     result = await provider.run(prompt, working_dir)
     if not result.success:

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -1,18 +1,26 @@
 """Quality-gate evaluator: decide whether a stage needs another iteration."""
 
 from app.config import Limits
+from app.prompts import GATE_EVALUATION
+from app.skills import render_prompt
 
 
 async def evaluate_should_iterate(
-    stage_output: str, working_dir: str, provider, limits: Limits = Limits()
+    stage_output: str,
+    working_dir: str,
+    provider,
+    limits: Limits = Limits(),
+    template: str = "",
 ) -> bool:
-    """Ask the given provider whether the stage output has blocking issues."""
-    prompt = (
-        "You are a quality gate agent. Review the following stage output and decide "
-        "whether it contains genuine issues that require another implementation iteration.\n\n"
-        "Answer ONLY with 'yes' if there are real issues that need fixing, "
-        "or 'no' if the output is satisfactory and the pipeline can proceed.\n\n"
-        f"STAGE OUTPUT:\n{stage_output[: limits.evaluation_output_chars]}"
+    """Ask the given provider whether the stage output has blocking issues.
+
+    ``template`` overrides the built-in prompt (config ``eval_skill``/``eval_prompt``
+    keys on the gate phase); it must keep the yes/no answer contract.
+    """
+    prompt = render_prompt(
+        template or GATE_EVALUATION,
+        "",
+        stage_output[: limits.evaluation_output_chars],
     )
     result = await provider.run(prompt, working_dir)
     if not result.success:

--- a/app/git.py
+++ b/app/git.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 
+from app.config import Limits
 from app.stages import Stage
 
 
@@ -69,6 +70,7 @@ async def run_commit_pr_stage(
     working_dir: str,
     on_stream=None,
     on_log=None,
+    limits: Limits = Limits(),
 ) -> str:
     """Commit changes with conventional commits and open a GitHub PR."""
     stage.start()
@@ -89,8 +91,8 @@ async def run_commit_pr_stage(
 
     conv_prompt = stage.prompt_template.format(
         prompt=prompt,
-        prev_output=prev_output[:3000],
-        diff_stat=diff_stat[:1500] if diff_stat else "No changes detected yet",
+        prev_output=prev_output[: limits.commit_context_chars],
+        diff_stat=diff_stat[: limits.diff_stat_chars] if diff_stat else "No changes detected yet",
     )
 
     conv_result = await stage.provider.run(conv_prompt, working_dir, on_stream=on_stream)

--- a/app/models.py
+++ b/app/models.py
@@ -82,6 +82,12 @@ class PipelineStats:
         return base
 
 
+def filter_tasks(tasks: list[Task], selected_ids: list[int]) -> list[Task]:
+    """Keep only the tasks whose id is in ``selected_ids``, preserving order."""
+    selected = set(selected_ids)
+    return [task for task in tasks if task.id in selected]
+
+
 def cost_cap_exceeded(stats: PipelineStats, max_cost_usd: float | None) -> bool:
     """True when a configured cost cap exists and accumulated cost reached it."""
     return max_cost_usd is not None and stats.total_cost_usd >= max_cost_usd

--- a/app/models.py
+++ b/app/models.py
@@ -82,4 +82,9 @@ class PipelineStats:
         return base
 
 
+def cost_cap_exceeded(stats: PipelineStats, max_cost_usd: float | None) -> bool:
+    """True when a configured cost cap exists and accumulated cost reached it."""
+    return max_cost_usd is not None and stats.total_cost_usd >= max_cost_usd
+
+
 pipeline_stats = PipelineStats()

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -1,5 +1,6 @@
 """Pipeline stage runners."""
 
+from app.config import Limits
 from app.models import Task
 from app.skills import render_prompt
 from app.stages import Stage
@@ -13,12 +14,13 @@ async def run_stage(
     working_dir: str,
     iteration_context: str = "",
     on_stream=None,
+    limits: Limits = Limits(),
 ) -> str:
     """Run a single pipeline stage (manager mode — single agent)."""
     stage.start()
 
     full_prompt = render_prompt(
-        stage.prompt_template, prompt, prev_output[:8000], iteration_context
+        stage.prompt_template, prompt, prev_output[: limits.prev_output_chars], iteration_context
     )
 
     result = await stage.provider.run(full_prompt, working_dir, on_stream=on_stream)
@@ -41,6 +43,7 @@ async def run_stage_parallel(
     on_worker_start=None,
     on_worker_complete=None,
     on_stream=None,
+    limits: Limits = Limits(),
 ) -> str:
     """Run a pipeline stage in parallel worker mode (fan-out to multiple agents)."""
     stage.start()
@@ -51,7 +54,7 @@ async def run_stage_parallel(
             prompt=prompt,
             task_description=task.description,
             task_files=", ".join(task.files) if task.files else "as needed",
-            prev_output=prev_output[:6000],
+            prev_output=prev_output[: limits.worker_prev_output_chars],
             iteration_context=iteration_context,
         )
         for task in tasks
@@ -62,6 +65,7 @@ async def run_stage_parallel(
         worker_prompts,
         working_dir,
         stage.provider,
+        max_ram_pct=limits.max_ram_pct,
         on_start=on_worker_start,
         on_complete=on_worker_complete,
         on_stream=on_stream,

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -10,6 +10,23 @@ PLANNING = (
     "Be specific and actionable. Output the plan in markdown."
 )
 
+DECOMPOSITION = (
+    "You are a task decomposition agent. Given a plan, break it into independent subtasks "
+    "that can be worked on IN PARALLEL by different engineers.\n\n"
+    "ORIGINAL TASK: {prompt}\n\n"
+    "PLAN:\n{prev_output}\n\n"
+    "Output a JSON array of subtasks. Each subtask should have:\n"
+    '- "id": sequential integer starting at 1\n'
+    '- "description": what to implement (be specific and self-contained, include enough context)\n'
+    '- "files": list of files this subtask will create or modify\n\n'
+    "Rules:\n"
+    "- Each subtask must be independent enough to work on in parallel\n"
+    "- Include enough context in each description so a worker can act without seeing other subtasks\n"
+    "- Create as many subtasks as the complexity genuinely requires — no artificial limit\n"
+    "- If the task is simple and cannot be split, return a single subtask\n"
+    "- Output ONLY the JSON array, no markdown fences or other text\n"
+)
+
 IMPLEMENTATION = (
     "You are a senior software engineer. Implement the following plan.\n\n"
     "ORIGINAL TASK: {prompt}\n\n"

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -27,6 +27,14 @@ DECOMPOSITION = (
     "- Output ONLY the JSON array, no markdown fences or other text\n"
 )
 
+GATE_EVALUATION = (
+    "You are a quality gate agent. Review the following stage output and decide "
+    "whether it contains genuine issues that require another implementation iteration.\n\n"
+    "Answer ONLY with 'yes' if there are real issues that need fixing, "
+    "or 'no' if the output is satisfactory and the pipeline can proceed.\n\n"
+    "STAGE OUTPUT:\n{prev_output}"
+)
+
 IMPLEMENTATION = (
     "You are a senior software engineer. Implement the following plan.\n\n"
     "ORIGINAL TASK: {prompt}\n\n"

--- a/app/providers/claude.py
+++ b/app/providers/claude.py
@@ -50,23 +50,32 @@ class ClaudeProvider:
 
     name = "claude"
 
-    def __init__(self, model: str = "", timeout_seconds: int = 600) -> None:
+    def __init__(
+        self,
+        model: str = "",
+        timeout_seconds: int = 600,
+        skip_permissions: bool = True,
+        extra_args: tuple[str, ...] = (),
+    ) -> None:
         self.model = model
         self.timeout_seconds = timeout_seconds
+        self.skip_permissions = skip_permissions
+        self.extra_args = tuple(extra_args)
+
+    def _build_cmd(self) -> list[str]:
+        cmd = ["claude", "--print"]
+        if self.skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        cmd += ["--output-format", "stream-json", "--verbose"]
+        if self.model:
+            cmd += ["--model", self.model]
+        cmd += list(self.extra_args)
+        return cmd
 
     async def run(
         self, prompt: str, working_dir: str, on_stream=None
     ) -> ProviderResult:
-        cmd = [
-            "claude",
-            "--print",
-            "--dangerously-skip-permissions",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-        ]
-        if self.model:
-            cmd += ["--model", self.model]
+        cmd = self._build_cmd()
 
         proc = None
         stderr_task: asyncio.Task | None = None

--- a/app/providers/claude.py
+++ b/app/providers/claude.py
@@ -6,8 +6,6 @@ import json
 from app.models import pipeline_stats
 from app.providers.base import ProviderResult
 
-_CLAUDE_TIMEOUT = 600  # seconds per subprocess call
-
 
 def parse_claude_stream_json(lines: list[str]) -> ProviderResult:
     """Parse Claude Code ``stream-json`` lines into a :class:`ProviderResult`.
@@ -52,8 +50,9 @@ class ClaudeProvider:
 
     name = "claude"
 
-    def __init__(self, model: str = "") -> None:
+    def __init__(self, model: str = "", timeout_seconds: int = 600) -> None:
         self.model = model
+        self.timeout_seconds = timeout_seconds
 
     async def run(
         self, prompt: str, working_dir: str, on_stream=None
@@ -98,7 +97,7 @@ class ClaudeProvider:
             lines: list[str] = []
             buf = b""
             try:
-                async with asyncio.timeout(_CLAUDE_TIMEOUT):
+                async with asyncio.timeout(self.timeout_seconds):
                     while True:
                         raw_chunk = await proc.stdout.read(65536)
                         if not raw_chunk:
@@ -120,7 +119,7 @@ class ClaudeProvider:
                                         await _emit(on_stream, block["text"])
             except asyncio.TimeoutError:
                 return ProviderResult(
-                    False, "", error=f"Timeout after {_CLAUDE_TIMEOUT}s", cost_usd=None
+                    False, "", error=f"Timeout after {self.timeout_seconds}s", cost_usd=None
                 )
 
             await stderr_task

--- a/app/providers/codex.py
+++ b/app/providers/codex.py
@@ -6,8 +6,6 @@ import json
 from app.models import pipeline_stats
 from app.providers.base import ProviderResult
 
-_CODEX_TIMEOUT = 600  # seconds per subprocess call
-
 
 def _extract_codex_error(message: str) -> str:
     """Codex wraps API errors as a JSON string inside ``message``; unwrap it."""
@@ -81,8 +79,9 @@ class CodexProvider:
 
     name = "codex"
 
-    def __init__(self, model: str = "") -> None:
+    def __init__(self, model: str = "", timeout_seconds: int = 600) -> None:
         self.model = model
+        self.timeout_seconds = timeout_seconds
 
     async def run(
         self, prompt: str, working_dir: str, on_stream=None
@@ -126,7 +125,7 @@ class CodexProvider:
             lines: list[str] = []
             buf = b""
             try:
-                async with asyncio.timeout(_CODEX_TIMEOUT):
+                async with asyncio.timeout(self.timeout_seconds):
                     while True:
                         raw_chunk = await proc.stdout.read(65536)
                         if not raw_chunk:
@@ -148,7 +147,7 @@ class CodexProvider:
                                     await _emit(on_stream, item.get("text", ""))
             except asyncio.TimeoutError:
                 return ProviderResult(
-                    False, "", error=f"Timeout after {_CODEX_TIMEOUT}s", cost_usd=None
+                    False, "", error=f"Timeout after {self.timeout_seconds}s", cost_usd=None
                 )
 
             await stderr_task

--- a/app/providers/codex.py
+++ b/app/providers/codex.py
@@ -79,22 +79,31 @@ class CodexProvider:
 
     name = "codex"
 
-    def __init__(self, model: str = "", timeout_seconds: int = 600) -> None:
+    def __init__(
+        self,
+        model: str = "",
+        timeout_seconds: int = 600,
+        skip_permissions: bool = True,
+        extra_args: tuple[str, ...] = (),
+    ) -> None:
         self.model = model
         self.timeout_seconds = timeout_seconds
+        self.skip_permissions = skip_permissions
+        self.extra_args = tuple(extra_args)
+
+    def _build_cmd(self) -> list[str]:
+        cmd = ["codex", "exec", "-", "--json"]
+        if self.skip_permissions:
+            cmd.append("--dangerously-bypass-approvals-and-sandbox")
+        if self.model:
+            cmd += ["-m", self.model]
+        cmd += list(self.extra_args)
+        return cmd
 
     async def run(
         self, prompt: str, working_dir: str, on_stream=None
     ) -> ProviderResult:
-        cmd = [
-            "codex",
-            "exec",
-            "-",
-            "--json",
-            "--dangerously-bypass-approvals-and-sandbox",
-        ]
-        if self.model:
-            cmd += ["-m", self.model]
+        cmd = self._build_cmd()
 
         proc = None
         stderr_task: asyncio.Task | None = None

--- a/app/providers/gemini.py
+++ b/app/providers/gemini.py
@@ -64,9 +64,26 @@ class GeminiProvider:
 
     name = "gemini"
 
-    def __init__(self, model: str = "", timeout_seconds: int = 600) -> None:
+    def __init__(
+        self,
+        model: str = "",
+        timeout_seconds: int = 600,
+        skip_permissions: bool = True,
+        extra_args: tuple[str, ...] = (),
+    ) -> None:
         self.model = model
         self.timeout_seconds = timeout_seconds
+        self.skip_permissions = skip_permissions
+        self.extra_args = tuple(extra_args)
+
+    def _build_cmd(self, prompt: str) -> list[str]:
+        cmd = ["gemini", "-p", prompt]
+        if self.skip_permissions:
+            cmd.append("--yolo")
+        if self.model:
+            cmd += ["-m", self.model]
+        cmd += list(self.extra_args)
+        return cmd
 
     async def _spawn(
         self, args: list[str], working_dir: str
@@ -111,9 +128,7 @@ class GeminiProvider:
     async def run(
         self, prompt: str, working_dir: str, on_stream=None
     ) -> ProviderResult:
-        base = ["gemini", "-p", prompt, "--yolo"]
-        if self.model:
-            base += ["-m", self.model]
+        base = self._build_cmd(prompt)
 
         rc, out, err = await self._spawn(base + ["--output-format", "json"], working_dir)
         if rc is None:

--- a/app/providers/gemini.py
+++ b/app/providers/gemini.py
@@ -7,8 +7,6 @@ import os
 from app.models import pipeline_stats
 from app.providers.base import ProviderResult
 
-_GEMINI_TIMEOUT = 600  # seconds per subprocess call
-
 
 def parse_gemini_json(text: str) -> ProviderResult:
     """Parse the single buffered JSON object ``gemini --output-format json`` emits.
@@ -66,8 +64,9 @@ class GeminiProvider:
 
     name = "gemini"
 
-    def __init__(self, model: str = "") -> None:
+    def __init__(self, model: str = "", timeout_seconds: int = 600) -> None:
         self.model = model
+        self.timeout_seconds = timeout_seconds
 
     async def _spawn(
         self, args: list[str], working_dir: str
@@ -88,10 +87,10 @@ class GeminiProvider:
                 env=env,
             )
             try:
-                async with asyncio.timeout(_GEMINI_TIMEOUT):
+                async with asyncio.timeout(self.timeout_seconds):
                     stdout, stderr = await proc.communicate()
             except asyncio.TimeoutError:
-                return None, "", f"Timeout after {_GEMINI_TIMEOUT}s"
+                return None, "", f"Timeout after {self.timeout_seconds}s"
             return (
                 proc.returncode,
                 stdout.decode(errors="replace"),

--- a/app/runner.py
+++ b/app/runner.py
@@ -173,7 +173,7 @@ class PipelineRunnerMixin:
 
         # ── Final status ─────────────────────────────────────────────────
         if self._artifacts is not None:
-            self._artifacts.finish(pipeline_stats, outcome is not RunOutcome.COMPLETED)
+            self._artifacts.finish(pipeline_stats, outcome.name.lower())
         stats = pipeline_stats
         final_stats = (
             f"Calls: {stats.total_calls} | Cost: {stats.format_cost()} "
@@ -600,7 +600,7 @@ class PipelineRunnerMixin:
                 break
 
         if self._artifacts is not None:
-            self._artifacts.finish(pipeline_stats, outcome is not RunOutcome.COMPLETED)
+            self._artifacts.finish(pipeline_stats, outcome.name.lower())
         stats = pipeline_stats
         final_stats = (
             f"Calls: {stats.total_calls} | Cost: {stats.format_cost()} "

--- a/app/runner.py
+++ b/app/runner.py
@@ -22,10 +22,11 @@ from app.agents import decompose_task
 from app.artifacts import RunArtifacts
 from app.confirm import ConfirmScreen
 from app.evaluation import evaluate_should_iterate
-from app.git import create_branch, run_commit_pr_stage
+from app.git import _git, create_branch, run_commit_pr_stage
 from app.config import (
     load_config,
     resolve_artifacts,
+    resolve_confirm,
     resolve_limits,
     resolve_pipeline,
     provider_for,
@@ -49,6 +50,22 @@ class PipelineRunnerMixin:
         """
         return bool(await self.push_screen_wait(ConfirmScreen(title, body)))
 
+    async def _confirm_before(self, stage) -> bool:
+        """Pre-phase confirmation gate; True = continue, False = user stopped."""
+        body = (
+            f"Stage: {stage.name}\n"
+            f"Provider: {stage.provider_name}\n"
+            f"Model: {stage.model or '(default)'}"
+        )
+        if stage.kind == "commit_pr":
+            _, status_out, _ = await _git(self.working_dir, "status", "--short")
+            _, diff_stat, _ = await _git(self.working_dir, "diff", "HEAD", "--stat")
+            body += (
+                f"\n\ngit status --short:\n{status_out or '(clean)'}"
+                f"\n\ngit diff HEAD --stat:\n{diff_stat or '(no diff)'}"
+            )
+        return await self._ask_confirm(f"Run {stage.name}?", body)
+
     def _resolve_or_report(self, stats_bar, prompt_input):
         """Resolve the configured pipeline, or report an invalid config and abort.
 
@@ -62,6 +79,7 @@ class PipelineRunnerMixin:
             self._limits = resolve_limits(config)
             self._artifacts_config = resolve_artifacts(config)
             self._artifacts = None
+            self._confirm = resolve_confirm(config, [stage.name for stage in stages])
             defaults = config.get("defaults", {})
             self._default_provider = provider_for(
                 defaults.get("provider", "claude"),
@@ -193,6 +211,12 @@ class PipelineRunnerMixin:
                 stats_bar.remove_class("working")
                 stats_bar.update("Cost cap reached")
                 return True
+            if stage.name in self._confirm.phases:
+                if not await self._confirm_before(stage):
+                    self._write_log(f"[yellow]Stopped by user before {stage.name}[/yellow]")
+                    stats_bar.remove_class("working")
+                    stats_bar.update("Stopped by user")
+                    return True
             stage_cost_before = pipeline_stats.total_cost_usd
             pill = pills[index] if index < len(pills) else None
             prev_output = outputs[index - 1] if index > 0 else ""
@@ -408,6 +432,12 @@ class PipelineRunnerMixin:
                 )
                 failed = True
                 break
+            if stage.name in self._confirm.phases:
+                if not await self._confirm_before(stage):
+                    self._write_log(f"[yellow]Stopped by user before {stage.name}[/yellow]")
+                    stats_bar.update("Stopped by user")
+                    failed = True
+                    break
             stage_cost_before = pipeline_stats.total_cost_usd
             pill = pills[index] if index < len(pills) else None
             if pill is not None:

--- a/app/runner.py
+++ b/app/runner.py
@@ -28,7 +28,7 @@ from app.config import (
     provider_for,
     preflight,
 )
-from app.models import Task, pipeline_stats
+from app.models import Task, cost_cap_exceeded, pipeline_stats
 from app.pipeline import run_stage, run_stage_parallel
 from app.pipeline_graph import gate_loopback_target, rerun_order, stage_prev
 from app.stages import StageStatus
@@ -162,6 +162,15 @@ class PipelineRunnerMixin:
 
         while index < len(stages):
             stage = stages[index]
+            if cost_cap_exceeded(pipeline_stats, self._limits.max_cost_usd):
+                self._write_log(
+                    f"[red]✗ Cost cap reached: ${pipeline_stats.total_cost_usd:.4f} ≥ "
+                    f"${self._limits.max_cost_usd:.2f} — stopping pipeline[/red]"
+                )
+                stats_bar.remove_class("working")
+                stats_bar.update("Cost cap reached")
+                return True
+            stage_cost_before = pipeline_stats.total_cost_usd
             pill = pills[index] if index < len(pills) else None
             prev_output = outputs[index - 1] if index > 0 else ""
             iteration_context = "" if stage.kind == "gate" else feedback
@@ -255,8 +264,10 @@ class PipelineRunnerMixin:
 
             outputs[index] = output
             self._stage_outputs[stage.name] = output
+            stage_cost_delta = pipeline_stats.total_cost_usd - stage_cost_before
+            cost_note = f" · ${stage_cost_delta:.4f}" if stage_cost_delta > 0 else ""
             self._write_log(
-                f"[green]✓ {stage.name}[/green] — {StagePill._fmt(stage.elapsed)}"
+                f"[green]✓ {stage.name}[/green] — {StagePill._fmt(stage.elapsed)}{cost_note}"
             )
             preview = output[:300].strip()
             if preview and stage.kind != "commit_pr":
@@ -355,6 +366,14 @@ class PipelineRunnerMixin:
 
         for index in range(from_idx, len(stages)):
             stage = stages[index]
+            if cost_cap_exceeded(pipeline_stats, self._limits.max_cost_usd):
+                self._write_log(
+                    f"[red]✗ Cost cap reached: ${pipeline_stats.total_cost_usd:.4f} ≥ "
+                    f"${self._limits.max_cost_usd:.2f} — stopping pipeline[/red]"
+                )
+                failed = True
+                break
+            stage_cost_before = pipeline_stats.total_cost_usd
             pill = pills[index] if index < len(pills) else None
             if pill is not None:
                 pill.update_status(StageStatus.RUNNING)
@@ -437,8 +456,10 @@ class PipelineRunnerMixin:
             if pill is not None:
                 pill.update_status(stage.status, stage.elapsed)
             if stage.status == StageStatus.COMPLETED:
+                stage_cost_delta = pipeline_stats.total_cost_usd - stage_cost_before
+                cost_note = f" · ${stage_cost_delta:.4f}" if stage_cost_delta > 0 else ""
                 self._write_log(
-                    f"[green]✓ {stage.name}[/green] — {StagePill._fmt(stage.elapsed)}"
+                    f"[green]✓ {stage.name}[/green] — {StagePill._fmt(stage.elapsed)}{cost_note}"
                 )
                 preview = output[:300].strip()
                 if preview and stage.kind != "commit_pr":

--- a/app/runner.py
+++ b/app/runner.py
@@ -191,7 +191,8 @@ class PipelineRunnerMixin:
                     plan_arg = f"{prev_output}\n\n{feedback}" if prev_output else feedback
                 stage.start()
                 decomposed_tasks = await decompose_task(
-                    prompt, plan_arg, self.working_dir, stage.provider
+                    prompt, plan_arg, self.working_dir, stage.provider,
+                    template=stage.prompt_template,
                 )
                 stage.complete(f"Decomposed into {len(decomposed_tasks)} subtasks")
                 self._last_decomposed_tasks = decomposed_tasks
@@ -390,7 +391,8 @@ class PipelineRunnerMixin:
                 )
                 stage.start()
                 decomposed_tasks = await decompose_task(
-                    prompt, prev_output, self.working_dir, stage.provider
+                    prompt, prev_output, self.working_dir, stage.provider,
+                    template=stage.prompt_template,
                 )
                 stage.complete(f"Decomposed into {len(decomposed_tasks)} subtasks")
                 self._last_decomposed_tasks = decomposed_tasks

--- a/app/runner.py
+++ b/app/runner.py
@@ -20,6 +20,7 @@ from textual.widgets import Label, RichLog, TextArea
 
 from app.agents import decompose_task
 from app.artifacts import RunArtifacts
+from app.confirm import ConfirmScreen
 from app.evaluation import evaluate_should_iterate
 from app.git import create_branch, run_commit_pr_stage
 from app.config import (
@@ -39,6 +40,14 @@ from app.widgets import StagePill
 
 class PipelineRunnerMixin:
     """Mixin providing run_pipeline and rerun_from_stage workers."""
+
+    async def _ask_confirm(self, title: str, body: str) -> bool:
+        """Show a blocking confirmation modal; True = continue, False = cancel.
+
+        Only safe from within a Textual worker (``run_pipeline`` /
+        ``rerun_from_stage`` are ``@work`` methods).
+        """
+        return bool(await self.push_screen_wait(ConfirmScreen(title, body)))
 
     def _resolve_or_report(self, stats_bar, prompt_input):
         """Resolve the configured pipeline, or report an invalid config and abort.

--- a/app/runner.py
+++ b/app/runner.py
@@ -54,6 +54,8 @@ class PipelineRunnerMixin:
                 defaults.get("provider", "claude"),
                 defaults.get("model", ""),
                 timeout_seconds=self._limits.provider_timeout_seconds,
+                skip_permissions=defaults.get("skip_permissions", True),
+                extra_args=tuple(defaults.get("extra_args", [])),
             )
             return stages
         except ValueError as exc:

--- a/app/runner.py
+++ b/app/runner.py
@@ -20,7 +20,7 @@ from textual.widgets import Label, RichLog, TextArea
 
 from app.agents import decompose_task
 from app.artifacts import RunArtifacts
-from app.confirm import ConfirmScreen
+from app.confirm import ConfirmScreen, TaskReviewScreen
 from app.evaluation import evaluate_should_iterate
 from app.git import _git, create_branch, run_commit_pr_stage
 from app.config import (
@@ -32,7 +32,7 @@ from app.config import (
     provider_for,
     preflight,
 )
-from app.models import Task, cost_cap_exceeded, pipeline_stats
+from app.models import Task, cost_cap_exceeded, filter_tasks, pipeline_stats
 from app.pipeline import run_stage, run_stage_parallel
 from app.pipeline_graph import gate_loopback_target, rerun_order, stage_prev
 from app.stages import StageStatus
@@ -261,6 +261,25 @@ class PipelineRunnerMixin:
                     self._write_log(
                         f"  [dim]#{task.id}: {task.description[:80]}  ({files})[/dim]"
                     )
+                if self._confirm.review_tasks:
+                    selected_ids = await self.push_screen_wait(
+                        TaskReviewScreen(decomposed_tasks)
+                    )
+                    if not selected_ids:
+                        self._write_log("[yellow]Stopped by user at task review[/yellow]")
+                        stats_bar.remove_class("working")
+                        stats_bar.update("Stopped by user")
+                        return True
+                    excluded = [
+                        task.id for task in decomposed_tasks if task.id not in selected_ids
+                    ]
+                    if excluded:
+                        self._write_log(
+                            f"[dim]Excluded task(s): "
+                            f"{', '.join(str(task_id) for task_id in excluded)}[/dim]"
+                        )
+                    decomposed_tasks = filter_tasks(decomposed_tasks, selected_ids)
+                    self._last_decomposed_tasks = decomposed_tasks
                 index += 1
                 continue
 
@@ -473,6 +492,24 @@ class PipelineRunnerMixin:
                     self._write_log(
                         f"  [dim]#{task.id}: {task.description[:80]}  ({files})[/dim]"
                     )
+                if self._confirm.review_tasks:
+                    selected_ids = await self.push_screen_wait(
+                        TaskReviewScreen(decomposed_tasks)
+                    )
+                    if not selected_ids:
+                        self._write_log("[yellow]Stopped by user at task review[/yellow]")
+                        failed = True
+                        break
+                    excluded = [
+                        task.id for task in decomposed_tasks if task.id not in selected_ids
+                    ]
+                    if excluded:
+                        self._write_log(
+                            f"[dim]Excluded task(s): "
+                            f"{', '.join(str(task_id) for task_id in excluded)}[/dim]"
+                        )
+                    decomposed_tasks = filter_tasks(decomposed_tasks, selected_ids)
+                    self._last_decomposed_tasks = decomposed_tasks
                 # Forward the plan unchanged; the decompose's product is the task
                 # list, not the "Decomposed into N subtasks" status line.
                 self._stage_outputs[stage.name] = prev_output

--- a/app/runner.py
+++ b/app/runner.py
@@ -279,6 +279,7 @@ class PipelineRunnerMixin:
                 should_loop = await evaluate_should_iterate(
                     output, self.working_dir, self._default_provider,
                     limits=self._limits,
+                    template=stage.eval_prompt_template,
                 )
                 target = gate_loopback_target(stages, index)
                 count = gate_iterations.get(index, 0)

--- a/app/runner.py
+++ b/app/runner.py
@@ -23,6 +23,7 @@ from app.evaluation import evaluate_should_iterate
 from app.git import create_branch, run_commit_pr_stage
 from app.config import (
     load_config,
+    resolve_limits,
     resolve_pipeline,
     provider_for,
     preflight,
@@ -47,9 +48,12 @@ class PipelineRunnerMixin:
         try:
             config = load_config(self.working_dir, getattr(self, "config_path", ""))
             stages = resolve_pipeline(config, self.working_dir)
+            self._limits = resolve_limits(config)
             defaults = config.get("defaults", {})
             self._default_provider = provider_for(
-                defaults.get("provider", "claude"), defaults.get("model", "")
+                defaults.get("provider", "claude"),
+                defaults.get("model", ""),
+                timeout_seconds=self._limits.provider_timeout_seconds,
             )
             return stages
         except ValueError as exc:

--- a/app/runner.py
+++ b/app/runner.py
@@ -19,10 +19,12 @@ from textual import work
 from textual.widgets import Label, RichLog, TextArea
 
 from app.agents import decompose_task
+from app.artifacts import RunArtifacts
 from app.evaluation import evaluate_should_iterate
 from app.git import create_branch, run_commit_pr_stage
 from app.config import (
     load_config,
+    resolve_artifacts,
     resolve_limits,
     resolve_pipeline,
     provider_for,
@@ -49,6 +51,8 @@ class PipelineRunnerMixin:
             config = load_config(self.working_dir, getattr(self, "config_path", ""))
             stages = resolve_pipeline(config, self.working_dir)
             self._limits = resolve_limits(config)
+            self._artifacts_config = resolve_artifacts(config)
+            self._artifacts = None
             defaults = config.get("defaults", {})
             self._default_provider = provider_for(
                 defaults.get("provider", "claude"),
@@ -109,6 +113,12 @@ class PipelineRunnerMixin:
         self._set_stream_header("Pipeline started…")
         self._write_log(f"[bold]Pipeline started:[/bold] {prompt}\n")
 
+        if self._artifacts_config.enabled:
+            self._artifacts = RunArtifacts.start(
+                self.working_dir, self._artifacts_config.dir, prompt
+            )
+            self._write_log(f"[dim]Artifacts → {self._artifacts.run_dir}[/dim]")
+
         # ── Branch creation (only when a commit_pr phase is present) ──────
         commit_stage = next((s for s in stages if s.kind == "commit_pr"), None)
         if commit_stage is not None:
@@ -127,6 +137,8 @@ class PipelineRunnerMixin:
         failed = await self._run_dispatch_loop(stages, pills, prompt, stats_bar)
 
         # ── Final status ─────────────────────────────────────────────────
+        if self._artifacts is not None:
+            self._artifacts.finish(pipeline_stats, failed)
         stats = pipeline_stats
         final_stats = (
             f"Calls: {stats.total_calls} | Cost: {stats.format_cost()} "
@@ -205,6 +217,8 @@ class PipelineRunnerMixin:
                 self._stage_outputs[stage.name] = prev_output
                 if pill is not None:
                     pill.update_status(StageStatus.COMPLETED, stage.elapsed)
+                if self._artifacts is not None:
+                    self._artifacts.record_stage(index, stage)
                 self._write_log(
                     f"[green]✓ {stage.name}[/green] — {StagePill._fmt(stage.elapsed)} "
                     f"→ [bold]{len(decomposed_tasks)} subtask(s)[/bold]"
@@ -258,6 +272,8 @@ class PipelineRunnerMixin:
 
             if pill is not None:
                 pill.update_status(stage.status, stage.elapsed)
+            if self._artifacts is not None:
+                self._artifacts.record_stage(index, stage)
 
             if stage.status != StageStatus.COMPLETED:
                 self._write_log(f"[red]✗ {stage.name} failed:[/red] {stage.error}")
@@ -353,6 +369,12 @@ class PipelineRunnerMixin:
         prev_output = self._stage_outputs.get(prev_name, "") if prev_name else ""
         prompt = self._last_prompt
 
+        if self._artifacts_config.enabled:
+            self._artifacts = RunArtifacts.start(
+                self.working_dir, self._artifacts_config.dir, prompt
+            )
+            self._write_log(f"[dim]Artifacts → {self._artifacts.run_dir}[/dim]")
+
         first_decompose = next(
             (i for i, s in enumerate(stages) if s.kind == "decompose"), None
         )
@@ -401,6 +423,8 @@ class PipelineRunnerMixin:
                 self._last_decomposed_tasks = decomposed_tasks
                 if pill is not None:
                     pill.update_status(StageStatus.COMPLETED, stage.elapsed)
+                if self._artifacts is not None:
+                    self._artifacts.record_stage(index, stage)
                 self._write_log(
                     f"[green]✓ {stage.name}[/green] — {StagePill._fmt(stage.elapsed)} "
                     f"→ [bold]{len(decomposed_tasks)} subtask(s)[/bold]"
@@ -460,6 +484,8 @@ class PipelineRunnerMixin:
 
             if pill is not None:
                 pill.update_status(stage.status, stage.elapsed)
+            if self._artifacts is not None:
+                self._artifacts.record_stage(index, stage)
             if stage.status == StageStatus.COMPLETED:
                 stage_cost_delta = pipeline_stats.total_cost_usd - stage_cost_before
                 cost_note = f" · ${stage_cost_delta:.4f}" if stage_cost_delta > 0 else ""
@@ -476,6 +502,8 @@ class PipelineRunnerMixin:
                 failed = True
                 break
 
+        if self._artifacts is not None:
+            self._artifacts.finish(pipeline_stats, failed)
         stats = pipeline_stats
         final_stats = (
             f"Calls: {stats.total_calls} | Cost: {stats.format_cost()} "

--- a/app/runner.py
+++ b/app/runner.py
@@ -200,6 +200,7 @@ class PipelineRunnerMixin:
         gate_iterations: dict[int, int] = {}
         feedback = ""
         index = 0
+        step_enabled = getattr(self, "step_mode", False) or self._confirm.step
 
         while index < len(stages):
             stage = stages[index]
@@ -376,6 +377,15 @@ class PipelineRunnerMixin:
                     )
                 feedback = ""
 
+            if step_enabled and stage.kind != "commit_pr" and index < len(stages) - 1:
+                if not await self._ask_confirm(
+                    f"{stage.name} completed — continue?", output
+                ):
+                    self._write_log(f"[yellow]Stopped by user after {stage.name}[/yellow]")
+                    stats_bar.remove_class("working")
+                    stats_bar.update("Stopped by user")
+                    return True
+
             index += 1
 
         return False
@@ -436,6 +446,7 @@ class PipelineRunnerMixin:
             else []
         )
         failed = False
+        step_enabled = getattr(self, "step_mode", False) or self._confirm.step
 
         self._write_log(
             f"\n[bold cyan]━━━ Re-running from: {from_stage_name} ━━━[/bold cyan]\n"
@@ -573,6 +584,15 @@ class PipelineRunnerMixin:
                     self._write_log(f"[dim]{preview}[/dim]\n")
                 self._stage_outputs[stage.name] = output
                 prev_output = output
+                if step_enabled and stage.kind != "commit_pr" and index < len(stages) - 1:
+                    if not await self._ask_confirm(
+                        f"{stage.name} completed — continue?", output
+                    ):
+                        self._write_log(
+                            f"[yellow]Stopped by user after {stage.name}[/yellow]"
+                        )
+                        failed = True
+                        break
             else:
                 self._write_log(f"[red]✗ {stage.name} failed:[/red] {stage.error}")
                 failed = True

--- a/app/runner.py
+++ b/app/runner.py
@@ -226,6 +226,7 @@ class PipelineRunnerMixin:
                     iteration_context=iteration_context,
                     on_worker_complete=on_worker_complete,
                     on_stream=on_parallel_stream,
+                    limits=self._limits,
                 )
             elif stage.kind == "commit_pr":
                 def on_pr_log(msg, _self=self):
@@ -234,11 +235,13 @@ class PipelineRunnerMixin:
                 output = await run_commit_pr_stage(
                     stage, prompt, prev_output, self.working_dir,
                     on_stream=on_stream, on_log=on_pr_log,
+                    limits=self._limits,
                 )
             else:  # simple or gate
                 output = await run_stage(
                     stage, prompt, prev_output, self.working_dir,
                     iteration_context=iteration_context, on_stream=on_stream,
+                    limits=self._limits,
                 )
 
             if pill is not None:
@@ -262,7 +265,8 @@ class PipelineRunnerMixin:
             # ── gate: evaluate, and loop back to the nearest decompose ───
             if stage.kind == "gate":
                 should_loop = await evaluate_should_iterate(
-                    output, self.working_dir, self._default_provider
+                    output, self.working_dir, self._default_provider,
+                    limits=self._limits,
                 )
                 target = gate_loopback_target(stages, index)
                 count = gate_iterations.get(index, 0)
@@ -270,7 +274,7 @@ class PipelineRunnerMixin:
                     gate_iterations[index] = count + 1
                     feedback = (
                         f"Code Quality & Technical Debt review #{count + 1} found issues "
-                        f"that require a full re-implementation pass:\n{output[:3000]}\n\n"
+                        f"that require a full re-implementation pass:\n{output[: self._limits.feedback_chars]}\n\n"
                         "Fix ALL reported quality and technical debt issues in the new implementation."
                     )
                     self._write_log(
@@ -410,6 +414,7 @@ class PipelineRunnerMixin:
                     stage, decomposed_tasks, prompt, prev_output, self.working_dir,
                     on_worker_complete=on_worker_complete,
                     on_stream=on_parallel_stream,
+                    limits=self._limits,
                 )
             elif stage.kind == "commit_pr":
                 self._write_log(f"\n[bold yellow]▶ {stage.name}[/bold yellow]")
@@ -420,11 +425,13 @@ class PipelineRunnerMixin:
                 output = await run_commit_pr_stage(
                     stage, prompt, prev_output, self.working_dir,
                     on_stream=on_stream, on_log=on_pr_log,
+                    limits=self._limits,
                 )
             else:  # simple or gate (single pass on re-run)
                 self._write_log(f"\n[bold yellow]▶ {stage.name}[/bold yellow]")
                 output = await run_stage(
-                    stage, prompt, prev_output, self.working_dir, on_stream=on_stream
+                    stage, prompt, prev_output, self.working_dir, on_stream=on_stream,
+                    limits=self._limits,
                 )
 
             if pill is not None:

--- a/app/runner.py
+++ b/app/runner.py
@@ -15,6 +15,8 @@ Requires the host class to define:
   - self.query(selector)
 """
 
+from enum import Enum, auto
+
 from textual import work
 from textual.widgets import Label, RichLog, TextArea
 
@@ -37,6 +39,12 @@ from app.pipeline import run_stage, run_stage_parallel
 from app.pipeline_graph import gate_loopback_target, rerun_order, stage_prev
 from app.stages import StageStatus
 from app.widgets import StagePill
+
+
+class RunOutcome(Enum):
+    COMPLETED = auto()
+    FAILED = auto()
+    STOPPED = auto()  # user checkpoint or cost cap — intentional, not an error
 
 
 class PipelineRunnerMixin:
@@ -161,11 +169,11 @@ class PipelineRunnerMixin:
             else:
                 self._write_log("[yellow]⚠ Branch creation skipped[/yellow]\n")
 
-        failed = await self._run_dispatch_loop(stages, pills, prompt, stats_bar)
+        outcome = await self._run_dispatch_loop(stages, pills, prompt, stats_bar)
 
         # ── Final status ─────────────────────────────────────────────────
         if self._artifacts is not None:
-            self._artifacts.finish(pipeline_stats, failed)
+            self._artifacts.finish(pipeline_stats, outcome is not RunOutcome.COMPLETED)
         stats = pipeline_stats
         final_stats = (
             f"Calls: {stats.total_calls} | Cost: {stats.format_cost()} "
@@ -173,11 +181,14 @@ class PipelineRunnerMixin:
         )
 
         stats_bar.remove_class("working")
-        if not failed:
+        if outcome is RunOutcome.COMPLETED:
             stats_bar.add_class("success")
             stats_bar.update(f"✓ Done — {final_stats}")
             self._write_log("\n[bold green]All stages completed![/bold green]")
             self._set_stream_header(f"Done — {final_stats}")
+        elif outcome is RunOutcome.STOPPED:
+            stats_bar.update(f"⏹ Stopped — {final_stats}")
+            self._set_stream_header(f"Stopped — {final_stats}")
         else:
             stats_bar.add_class("error")
             stats_bar.update(f"✗ Failed — {final_stats}")
@@ -187,13 +198,12 @@ class PipelineRunnerMixin:
         for pill in self.query(StagePill):
             pill.add_class("pill-rerunnable")
 
-    async def _run_dispatch_loop(self, stages, pills, prompt, stats_bar) -> bool:
+    async def _run_dispatch_loop(self, stages, pills, prompt, stats_bar) -> RunOutcome:
         """Run the resolved pipeline, dispatching each stage by ``kind``.
 
-        Threads each stage's output to the next, re-runs a ``gate``'s loop-back
-        range (nearest preceding ``decompose`` .. gate) when it asks for another
-        iteration — capped by the gate's ``max_iterations`` — and returns
-        ``True`` if any stage failed.
+        Threads each stage's output to the next, and re-runs a ``gate``'s
+        loop-back range (nearest preceding ``decompose`` .. gate) when it asks
+        for another iteration — capped by the gate's ``max_iterations``.
         """
         outputs: list[str] = [""] * len(stages)
         decomposed_tasks: list[Task] = []
@@ -209,15 +219,11 @@ class PipelineRunnerMixin:
                     f"[red]✗ Cost cap reached: ${pipeline_stats.total_cost_usd:.4f} ≥ "
                     f"${self._limits.max_cost_usd:.2f} — stopping pipeline[/red]"
                 )
-                stats_bar.remove_class("working")
-                stats_bar.update("Cost cap reached")
-                return True
+                return RunOutcome.STOPPED
             if stage.name in self._confirm.phases:
                 if not await self._confirm_before(stage):
                     self._write_log(f"[yellow]Stopped by user before {stage.name}[/yellow]")
-                    stats_bar.remove_class("working")
-                    stats_bar.update("Stopped by user")
-                    return True
+                    return RunOutcome.STOPPED
             stage_cost_before = pipeline_stats.total_cost_usd
             pill = pills[index] if index < len(pills) else None
             prev_output = outputs[index - 1] if index > 0 else ""
@@ -268,9 +274,7 @@ class PipelineRunnerMixin:
                     )
                     if not selected_ids:
                         self._write_log("[yellow]Stopped by user at task review[/yellow]")
-                        stats_bar.remove_class("working")
-                        stats_bar.update("Stopped by user")
-                        return True
+                        return RunOutcome.STOPPED
                     excluded = [
                         task.id for task in decomposed_tasks if task.id not in selected_ids
                     ]
@@ -332,7 +336,7 @@ class PipelineRunnerMixin:
                 self._write_log(f"[red]✗ {stage.name} failed:[/red] {stage.error}")
                 stats_bar.remove_class("working")
                 stats_bar.update(f"Failed at: {stage.name}")
-                return True
+                return RunOutcome.FAILED
 
             outputs[index] = output
             self._stage_outputs[stage.name] = output
@@ -382,13 +386,11 @@ class PipelineRunnerMixin:
                     f"{stage.name} completed — continue?", output
                 ):
                     self._write_log(f"[yellow]Stopped by user after {stage.name}[/yellow]")
-                    stats_bar.remove_class("working")
-                    stats_bar.update("Stopped by user")
-                    return True
+                    return RunOutcome.STOPPED
 
             index += 1
 
-        return False
+        return RunOutcome.COMPLETED
 
     @work(exclusive=True)
     async def rerun_from_stage(self, from_stage_name: str) -> None:
@@ -445,7 +447,7 @@ class PipelineRunnerMixin:
             if first_decompose is not None and from_idx > first_decompose
             else []
         )
-        failed = False
+        outcome = RunOutcome.COMPLETED
         step_enabled = getattr(self, "step_mode", False) or self._confirm.step
 
         self._write_log(
@@ -460,13 +462,12 @@ class PipelineRunnerMixin:
                     f"[red]✗ Cost cap reached: ${pipeline_stats.total_cost_usd:.4f} ≥ "
                     f"${self._limits.max_cost_usd:.2f} — stopping pipeline[/red]"
                 )
-                failed = True
+                outcome = RunOutcome.STOPPED
                 break
             if stage.name in self._confirm.phases:
                 if not await self._confirm_before(stage):
                     self._write_log(f"[yellow]Stopped by user before {stage.name}[/yellow]")
-                    stats_bar.update("Stopped by user")
-                    failed = True
+                    outcome = RunOutcome.STOPPED
                     break
             stage_cost_before = pipeline_stats.total_cost_usd
             pill = pills[index] if index < len(pills) else None
@@ -509,7 +510,7 @@ class PipelineRunnerMixin:
                     )
                     if not selected_ids:
                         self._write_log("[yellow]Stopped by user at task review[/yellow]")
-                        failed = True
+                        outcome = RunOutcome.STOPPED
                         break
                     excluded = [
                         task.id for task in decomposed_tasks if task.id not in selected_ids
@@ -591,15 +592,15 @@ class PipelineRunnerMixin:
                         self._write_log(
                             f"[yellow]Stopped by user after {stage.name}[/yellow]"
                         )
-                        failed = True
+                        outcome = RunOutcome.STOPPED
                         break
             else:
                 self._write_log(f"[red]✗ {stage.name} failed:[/red] {stage.error}")
-                failed = True
+                outcome = RunOutcome.FAILED
                 break
 
         if self._artifacts is not None:
-            self._artifacts.finish(pipeline_stats, failed)
+            self._artifacts.finish(pipeline_stats, outcome is not RunOutcome.COMPLETED)
         stats = pipeline_stats
         final_stats = (
             f"Calls: {stats.total_calls} | Cost: {stats.format_cost()} "
@@ -607,11 +608,14 @@ class PipelineRunnerMixin:
         )
 
         stats_bar.remove_class("working")
-        if not failed:
+        if outcome is RunOutcome.COMPLETED:
             stats_bar.add_class("success")
             stats_bar.update(f"✓ Done — {final_stats}")
             self._write_log("\n[bold green]Re-run complete![/bold green]")
             self._set_stream_header(f"Done — {final_stats}")
+        elif outcome is RunOutcome.STOPPED:
+            stats_bar.update(f"⏹ Stopped — {final_stats}")
+            self._set_stream_header(f"Stopped — {final_stats}")
         else:
             stats_bar.add_class("error")
             stats_bar.update(f"✗ Failed — {final_stats}")

--- a/app/stages.py
+++ b/app/stages.py
@@ -57,7 +57,7 @@ VALID_KINDS = {"simple", "decompose", "parallel", "gate", "commit_pr"}
 
 STAGES = [
     Stage(name="Planning",          prompt_template=p.PLANNING, kind="simple"),
-    Stage(name="Decomposition",     prompt_template="", kind="decompose"),
+    Stage(name="Decomposition",     prompt_template=p.DECOMPOSITION, kind="decompose"),
     Stage(name="Implementation",    prompt_template=p.IMPLEMENTATION,
           worker_prompt_template=p.IMPLEMENTATION_WORKER, iterable=True, parallel=True,
           kind="parallel"),

--- a/app/stages.py
+++ b/app/stages.py
@@ -24,6 +24,7 @@ class Stage:
     iterable: bool = False
     parallel: bool = False
     worker_prompt_template: str = ""
+    eval_prompt_template: str = ""
     provider: LLMProvider | None = None
     provider_name: str = "claude"
     model: str = ""

--- a/app/styles.tcss
+++ b/app/styles.tcss
@@ -189,3 +189,37 @@ Screen {
 #net-in-spark > .sparkline--max-color {
     color: $secondary;
 }
+
+/* ── Confirmation modals ─────────────────────────────────────────── */
+ConfirmScreen, TaskReviewScreen {
+    align: center middle;
+}
+
+#confirm-panel, #task-review-panel {
+    width: 80;
+    height: auto;
+    max-height: 80%;
+    border: round $accent;
+    background: $surface;
+    padding: 1 2;
+}
+
+#confirm-title, #task-review-title {
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#confirm-body-scroll, #task-review-scroll {
+    height: auto;
+    max-height: 20;
+    margin-bottom: 1;
+}
+
+#confirm-buttons, #task-review-buttons {
+    height: 3;
+    align-horizontal: right;
+}
+
+#confirm-buttons Button, #task-review-buttons Button {
+    margin-left: 2;
+}

--- a/app/tui.py
+++ b/app/tui.py
@@ -20,11 +20,12 @@ from app.widgets import StagePill, SystemMonitor
 class PipelineApp(PipelineRunnerMixin, App):
     """Multi-agent Dev Pipeline TUI."""
 
-    def __init__(self, working_dir: str = "", prompt_file: str = "", config_path: str = "", **kwargs):
+    def __init__(self, working_dir: str = "", prompt_file: str = "", config_path: str = "", step_mode: bool = False, **kwargs):
         import os
         self.working_dir = working_dir or os.getcwd()
         self.prompt_file = prompt_file
         self.config_path = config_path
+        self.step_mode = step_mode
         super().__init__(**kwargs)
 
     TITLE = "Dev Pipeline — Multi-Agent"
@@ -180,6 +181,7 @@ def main():
     parser.add_argument("-f", "--prompt-file", default="", metavar="FILE", help="Read prompt from FILE and start pipeline immediately")
     parser.add_argument("--config", default="", metavar="PATH", help="Path to a step-by-step.toml provider config (overrides project/user config)")
     parser.add_argument("--check", action="store_true", help="Validate the config and print the resolved pipeline without running anything")
+    parser.add_argument("--step", action="store_true", help="Pause after each completed stage until you confirm")
     args = parser.parse_args()
 
     repo = os.path.abspath(os.path.expanduser(args.repo))
@@ -206,7 +208,7 @@ def main():
 
         raise SystemExit(run_check(repo, config_path))
 
-    app = PipelineApp(working_dir=repo, prompt_file=prompt_file, config_path=config_path)
+    app = PipelineApp(working_dir=repo, prompt_file=prompt_file, config_path=config_path, step_mode=args.step)
     app.run()
 
 

--- a/app/tui.py
+++ b/app/tui.py
@@ -8,6 +8,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, HorizontalScroll, Vertical
 from textual.css.query import NoMatches
 from textual.reactive import var
+from textual.screen import ModalScreen
 from textual.widgets import Header, Label, RichLog, Static, TextArea
 
 from app.config import load_config, resolve_pipeline
@@ -37,6 +38,7 @@ class PipelineApp(PipelineRunnerMixin, App):
         Binding("ctrl+enter", "submit_prompt", "Run", key_display="ctrl+↵"),
         Binding("ctrl+e", "export_log", "Export Log"),
         Binding("ctrl+m", "toggle_monitor", "Monitor"),
+        Binding("ctrl+x", "cancel_run", "Cancel"),
     ]
 
     _log_buffer: list[str] = []
@@ -79,7 +81,7 @@ class PipelineApp(PipelineRunnerMixin, App):
             yield Static(
                 " [dim]^p[/dim] palette  [dim]^l[/dim] Clear Log"
                 "  [dim]ctrl+↵[/dim] Run  [dim]^e[/dim] Export Log"
-                "  [dim]^m[/dim] Monitor",
+                "  [dim]^m[/dim] Monitor  [dim]^x[/dim] Cancel",
                 id="footer-keys",
             )
             yield Label("Calls: 0  |  Cost: $0.000  |  Time: 0s", id="stats-bar")
@@ -165,6 +167,23 @@ class PipelineApp(PipelineRunnerMixin, App):
         with open(path, "w") as f:
             f.write(plain)
         self._write_log(f"[green]Log exported →[/green] {path}")
+
+    def action_cancel_run(self) -> None:
+        if not self.running:
+            return
+        self.workers.cancel_all()
+        while isinstance(self.screen, ModalScreen):
+            self.pop_screen()
+        self.running = False
+        self.query_one("#prompt-input", TextArea).disabled = False
+        stats_bar = self.query_one("#stats-bar", Label)
+        stats_bar.remove_class("working", "success")
+        stats_bar.add_class("error")
+        stats_bar.update("Cancelled")
+        self._set_stream_header("Cancelled")
+        self._write_log("[red]✗ Run cancelled by user[/red]")
+        for pill in self.query(StagePill):
+            pill.add_class("pill-rerunnable")
 
     def on_stage_pill_clicked(self, event: StagePill.Clicked) -> None:
         if self.running or not self._last_prompt:

--- a/app/tui.py
+++ b/app/tui.py
@@ -179,6 +179,7 @@ def main():
     parser.add_argument("repo", nargs="?", default=os.getcwd(), help="Path to the target repository (default: current directory)")
     parser.add_argument("-f", "--prompt-file", default="", metavar="FILE", help="Read prompt from FILE and start pipeline immediately")
     parser.add_argument("--config", default="", metavar="PATH", help="Path to a step-by-step.toml provider config (overrides project/user config)")
+    parser.add_argument("--check", action="store_true", help="Validate the config and print the resolved pipeline without running anything")
     args = parser.parse_args()
 
     repo = os.path.abspath(os.path.expanduser(args.repo))
@@ -199,6 +200,11 @@ def main():
         if not os.path.isfile(config_path):
             print(f"Error: config file '{config_path}' not found")
             raise SystemExit(1)
+
+    if args.check:
+        from app.check import run_check
+
+        raise SystemExit(run_check(repo, config_path))
 
     app = PipelineApp(working_dir=repo, prompt_file=prompt_file, config_path=config_path)
     app.run()

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "step-by-step-cli",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "LLM Development Pipeline UI — GitHub Actions-style multi-agent pipeline powered by Claude",
   "keywords": [
     "llm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "step-by-step-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "LLM Development Pipeline UI - GitHub Actions-style visual dashboard for LLM-driven workflows"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from app.agents import decompose_task
+from app.evaluation import evaluate_should_iterate
 from app.providers.base import ProviderResult
 
 
@@ -40,6 +41,17 @@ def test_default_decompose_template_used_when_empty(tmp_path):
     assert "ORIGINAL TASK: my task" in rendered
     assert "PLAN:\nthe plan" in rendered
     assert "JSON array" in rendered
+
+
+def test_custom_eval_template_sent_with_stage_output(tmp_path):
+    provider = _StubProvider(output="yes")
+    should_iterate = asyncio.run(
+        evaluate_should_iterate(
+            "the output", str(tmp_path), provider, template="JUDGE: {prev_output}"
+        )
+    )
+    assert provider.prompts == ["JUDGE: the output"]
+    assert should_iterate is True
 
 
 def test_non_json_output_falls_back_to_single_task(tmp_path):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from app.agents import decompose_task
+from app.providers.base import ProviderResult
+
+
+class _StubProvider:
+    name = "stub"
+
+    def __init__(self, output="[]", success=True):
+        self.output = output
+        self.success = success
+        self.prompts = []
+
+    async def run(self, prompt, working_dir, on_stream=None):
+        self.prompts.append(prompt)
+        return ProviderResult(self.success, self.output, cost_usd=None)
+
+
+def test_custom_decompose_template_used_with_substitutions(tmp_path):
+    provider = _StubProvider(output='[{"id": 1, "description": "d"}]')
+    tasks = asyncio.run(
+        decompose_task(
+            "my task",
+            "the plan",
+            str(tmp_path),
+            provider,
+            template="SPLIT {prompt} USING {prev_output}",
+        )
+    )
+    assert provider.prompts == ["SPLIT my task USING the plan"]
+    assert len(tasks) == 1
+    assert tasks[0].description == "d"
+
+
+def test_default_decompose_template_used_when_empty(tmp_path):
+    provider = _StubProvider(output='[{"id": 1, "description": "d"}]')
+    asyncio.run(decompose_task("my task", "the plan", str(tmp_path), provider))
+    rendered = provider.prompts[0]
+    assert "ORIGINAL TASK: my task" in rendered
+    assert "PLAN:\nthe plan" in rendered
+    assert "JSON array" in rendered
+
+
+def test_non_json_output_falls_back_to_single_task(tmp_path):
+    provider = _StubProvider(output="not json at all")
+    tasks = asyncio.run(decompose_task("my task", "plan", str(tmp_path), provider))
+    assert len(tasks) == 1
+    assert tasks[0].id == 1
+    assert tasks[0].description == "my task"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from app.agents import decompose_task
+from app.config import Limits
 from app.evaluation import evaluate_should_iterate
 from app.providers.base import ProviderResult
 
@@ -52,6 +53,20 @@ def test_custom_eval_template_sent_with_stage_output(tmp_path):
     )
     assert provider.prompts == ["JUDGE: the output"]
     assert should_iterate is True
+
+
+def test_default_eval_template_truncates_stage_output_per_limits(tmp_path):
+    provider = _StubProvider(output="no")
+    should_iterate = asyncio.run(
+        evaluate_should_iterate(
+            "x" * 100, str(tmp_path), provider, limits=Limits(evaluation_output_chars=10)
+        )
+    )
+    assert should_iterate is False
+    rendered = provider.prompts[0]
+    assert "quality gate agent" in rendered
+    assert "x" * 10 in rendered
+    assert "x" * 11 not in rendered
 
 
 def test_non_json_output_falls_back_to_single_task(tmp_path):

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -42,6 +42,19 @@ def test_failed_stage_records_error(tmp_path):
     assert "status: failed" in content
 
 
+def test_gate_rerun_records_each_attempt(tmp_path):
+    artifacts = RunArtifacts.start(str(tmp_path), "runs", "p")
+    stage = Stage(name="Implementation", prompt_template="")
+    stage.start()
+    stage.complete("attempt one")
+    artifacts.record_stage(2, stage)
+    stage.start()
+    stage.complete("attempt two")
+    artifacts.record_stage(2, stage)
+    assert "attempt one" in (artifacts.run_dir / "03-implementation.md").read_text()
+    assert "attempt two" in (artifacts.run_dir / "03-implementation-2.md").read_text()
+
+
 def test_start_is_collision_safe(tmp_path, monkeypatch):
     real_datetime = artifacts_module.datetime
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from app import artifacts as artifacts_module
+from app.artifacts import RunArtifacts
+from app.config import Artifacts, resolve_artifacts
+from app.models import PipelineStats
+from app.stages import Stage
+
+
+def test_start_record_finish_produce_expected_files(tmp_path):
+    artifacts = RunArtifacts.start(str(tmp_path), ".step-by-step/runs", "do the thing")
+    assert (artifacts.run_dir / "prompt.txt").read_text() == "do the thing"
+
+    stage = Stage(name="Tests & Validation", prompt_template="")
+    stage.start()
+    stage.complete("all good")
+    artifacts.record_stage(3, stage)
+    stage_file = artifacts.run_dir / "04-tests-validation.md"
+    content = stage_file.read_text()
+    assert "all good" in content
+    assert "status: completed" in content
+
+    stats = PipelineStats()
+    stats.add_call(0.5)
+    artifacts.finish(stats, failed=False)
+    payload = json.loads((artifacts.run_dir / "run.json").read_text())
+    assert payload["total_calls"] == 1
+    assert payload["total_cost_usd"] == 0.5
+    assert payload["failed"] is False
+
+
+def test_failed_stage_records_error(tmp_path):
+    artifacts = RunArtifacts.start(str(tmp_path), "runs", "p")
+    stage = Stage(name="Planning", prompt_template="")
+    stage.start()
+    stage.fail("boom")
+    artifacts.record_stage(0, stage)
+    content = (artifacts.run_dir / "01-planning.md").read_text()
+    assert "boom" in content
+    assert "status: failed" in content
+
+
+def test_start_is_collision_safe(tmp_path, monkeypatch):
+    real_datetime = artifacts_module.datetime
+
+    class _Frozen:
+        @staticmethod
+        def now():
+            return real_datetime(2026, 1, 1, 12, 0, 0)
+
+    monkeypatch.setattr(artifacts_module, "datetime", _Frozen)
+    first = RunArtifacts.start(str(tmp_path), "runs", "p")
+    second = RunArtifacts.start(str(tmp_path), "runs", "p")
+    assert first.run_dir != second.run_dir
+    assert second.run_dir.name == "20260101_120000-2"
+
+
+def test_resolve_artifacts_defaults():
+    assert resolve_artifacts({}) == Artifacts()
+    assert resolve_artifacts({}).enabled is False
+
+
+def test_resolve_artifacts_unknown_key_rejected():
+    with pytest.raises(ValueError, match="Unknown key\\(s\\) in \\[artifacts\\]: enable"):
+        resolve_artifacts({"artifacts": {"enable": True}})

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -72,7 +72,6 @@ def test_start_is_collision_safe(tmp_path, monkeypatch):
 
 def test_resolve_artifacts_defaults():
     assert resolve_artifacts({}) == Artifacts()
-    assert resolve_artifacts({}).enabled is False
 
 
 def test_resolve_artifacts_unknown_key_rejected():

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -24,11 +24,11 @@ def test_start_record_finish_produce_expected_files(tmp_path):
 
     stats = PipelineStats()
     stats.add_call(0.5)
-    artifacts.finish(stats, failed=False)
+    artifacts.finish(stats, "stopped")
     payload = json.loads((artifacts.run_dir / "run.json").read_text())
     assert payload["total_calls"] == 1
     assert payload["total_cost_usd"] == 0.5
-    assert payload["failed"] is False
+    assert payload["outcome"] == "stopped"
 
 
 def test_failed_stage_records_error(tmp_path):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,62 @@
+import textwrap
+
+from app import config as config_module
+from app.check import run_check
+
+
+def _write(path, content):
+    path.write_text(textwrap.dedent(content))
+
+
+def test_valid_config_prints_phases_and_returns_0(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.setattr(config_module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(repo / "step-by-step.toml", '[defaults]\nprovider="claude"\n')
+
+    code = run_check(str(repo), "")
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "step-by-step.toml" in out
+    assert "Planning" in out and "Commit & PR" in out
+    assert "provider_timeout_seconds = 600" in out
+    assert "all provider CLIs found" in out
+
+
+def test_unknown_provider_returns_1_with_message(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(repo / "step-by-step.toml", '[defaults]\nprovider="gpt"\n')
+
+    code = run_check(str(repo), "")
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "Config error" in out
+    assert "Unknown provider" in out
+
+
+def test_no_config_reports_builtin_default(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.setattr(config_module.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    code = run_check(str(tmp_path), "")
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "built-in default" in out
+
+
+def test_missing_provider_cli_is_reported_but_returns_0(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.setattr(config_module.shutil, "which", lambda name: None)
+
+    code = run_check(str(tmp_path), "")
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "Preflight:" in out
+    assert "claude" in out

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -2,7 +2,14 @@ import asyncio
 
 import pytest
 
-from app.config import Limits, provider_for, resolve_limits, resolve_pipeline
+from app.config import (
+    Confirm,
+    Limits,
+    provider_for,
+    resolve_confirm,
+    resolve_limits,
+    resolve_pipeline,
+)
 from app.pipeline import run_stage
 from app.providers.base import ProviderResult
 from app.stages import Stage
@@ -97,6 +104,30 @@ def test_configured_timeout_propagates_through_resolve_pipeline(tmp_path):
     config = {"limits": {"provider_timeout_seconds": 1200}}
     stages = resolve_pipeline(config, str(tmp_path))
     assert all(stage.provider.timeout_seconds == 1200 for stage in stages)
+
+
+def test_resolve_confirm_defaults():
+    assert resolve_confirm({}, ["Planning"]) == Confirm()
+
+
+def test_resolve_confirm_unknown_key_rejected():
+    with pytest.raises(ValueError, match="Unknown key\\(s\\) in \\[confirm\\]: pause"):
+        resolve_confirm({"confirm": {"pause": True}}, ["Planning"])
+
+
+def test_resolve_confirm_unknown_phase_rejected():
+    with pytest.raises(ValueError, match="not in the pipeline: Bogus"):
+        resolve_confirm({"confirm": {"phases": ["Bogus"]}}, ["Planning"])
+
+
+def test_resolve_confirm_valid_settings_accepted():
+    confirm = resolve_confirm(
+        {"confirm": {"phases": ["Planning"], "step": True, "review_tasks": True}},
+        ["Planning", "Commit & PR"],
+    )
+    assert confirm.phases == ("Planning",)
+    assert confirm.step is True
+    assert confirm.review_tasks is True
 
 
 def test_explicit_phase_max_iterations_wins_over_default(tmp_path):

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -6,6 +6,7 @@ from app.config import (
     Confirm,
     Limits,
     provider_for,
+    resolve_artifacts,
     resolve_confirm,
     resolve_limits,
     resolve_pipeline,
@@ -27,13 +28,7 @@ class _RecordingProvider:
 
 
 def test_defaults_when_section_absent():
-    limits = resolve_limits({})
-    assert limits == Limits()
-    assert limits.provider_timeout_seconds == 600
-    assert limits.max_ram_pct == 75.0
-    assert limits.max_cost_usd is None
-    assert limits.default_max_iterations == 3
-    assert limits.prev_output_chars == 8000
+    assert resolve_limits({}) == Limits()
 
 
 def test_overrides_applied_and_ints_accepted_for_float_fields():
@@ -104,6 +99,36 @@ def test_configured_timeout_propagates_through_resolve_pipeline(tmp_path):
     config = {"limits": {"provider_timeout_seconds": 1200}}
     stages = resolve_pipeline(config, str(tmp_path))
     assert all(stage.provider.timeout_seconds == 1200 for stage in stages)
+
+
+@pytest.mark.parametrize(
+    "resolve, match",
+    [
+        (
+            lambda: resolve_pipeline({"defaults": {"skip_permissions": "yes"}}, "."),
+            "skip_permissions must be a boolean",
+        ),
+        (
+            lambda: resolve_confirm({"confirm": {"step": "yes"}}, ["Planning"]),
+            "step must be a boolean",
+        ),
+        (
+            lambda: resolve_confirm({"confirm": {"phases": "Planning"}}, ["Planning"]),
+            "phases must be a list of strings",
+        ),
+        (
+            lambda: resolve_artifacts({"artifacts": {"enabled": "yes"}}),
+            "enabled must be a boolean",
+        ),
+        (
+            lambda: resolve_artifacts({"artifacts": {"dir": ""}}),
+            "dir must be a non-empty string",
+        ),
+    ],
+)
+def test_invalid_config_value_types_rejected(resolve, match):
+    with pytest.raises(ValueError, match=match):
+        resolve()
 
 
 def test_resolve_confirm_defaults():

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,70 @@
+import pytest
+
+from app.config import Limits, resolve_limits, resolve_pipeline
+
+
+def test_defaults_when_section_absent():
+    limits = resolve_limits({})
+    assert limits == Limits()
+    assert limits.provider_timeout_seconds == 600
+    assert limits.max_ram_pct == 75.0
+    assert limits.max_cost_usd is None
+    assert limits.default_max_iterations == 3
+    assert limits.prev_output_chars == 8000
+
+
+def test_overrides_applied_and_ints_accepted_for_float_fields():
+    limits = resolve_limits(
+        {
+            "limits": {
+                "provider_timeout_seconds": 1200,
+                "max_ram_pct": 60,
+                "max_cost_usd": 5,
+                "prev_output_chars": 12000,
+            }
+        }
+    )
+    assert limits.provider_timeout_seconds == 1200
+    assert limits.max_ram_pct == 60.0
+    assert limits.max_cost_usd == 5.0
+    assert limits.prev_output_chars == 12000
+    assert limits.worker_prev_output_chars == 6000  # untouched default
+
+
+def test_unknown_key_rejected():
+    with pytest.raises(ValueError, match="Unknown key\\(s\\) in \\[limits\\]: timeout"):
+        resolve_limits({"limits": {"timeout": 600}})
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("max_ram_pct", 0),
+        ("max_ram_pct", 150),
+        ("provider_timeout_seconds", -1),
+        ("provider_timeout_seconds", 1.5),
+        ("max_cost_usd", 0),
+        ("feedback_chars", 0),
+        ("default_max_iterations", True),
+    ],
+)
+def test_bad_ranges_rejected(key, value):
+    with pytest.raises(ValueError, match=f"\\[limits\\] {key} must be"):
+        resolve_limits({"limits": {key: value}})
+
+
+def test_default_max_iterations_reaches_stage(tmp_path):
+    config = {"limits": {"default_max_iterations": 5}}
+    stages = resolve_pipeline(config, str(tmp_path))
+    gate = next(stage for stage in stages if stage.kind == "gate")
+    assert gate.max_iterations == 5
+
+
+def test_explicit_phase_max_iterations_wins_over_default(tmp_path):
+    config = {
+        "limits": {"default_max_iterations": 5},
+        "phases": {"Code Quality": {"max_iterations": 2}},
+    }
+    stages = resolve_pipeline(config, str(tmp_path))
+    gate = next(stage for stage in stages if stage.kind == "gate")
+    assert gate.max_iterations == 2

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,6 +1,22 @@
+import asyncio
+
 import pytest
 
 from app.config import Limits, provider_for, resolve_limits, resolve_pipeline
+from app.pipeline import run_stage
+from app.providers.base import ProviderResult
+from app.stages import Stage
+
+
+class _RecordingProvider:
+    name = "stub"
+
+    def __init__(self):
+        self.prompts = []
+
+    async def run(self, prompt, working_dir, on_stream=None):
+        self.prompts.append(prompt)
+        return ProviderResult(True, "ok", cost_usd=None)
 
 
 def test_defaults_when_section_absent():
@@ -58,6 +74,18 @@ def test_default_max_iterations_reaches_stage(tmp_path):
     stages = resolve_pipeline(config, str(tmp_path))
     gate = next(stage for stage in stages if stage.kind == "gate")
     assert gate.max_iterations == 5
+
+
+def test_run_stage_truncates_prev_output_per_limits(tmp_path):
+    provider = _RecordingProvider()
+    stage = Stage(name="X", prompt_template="PREV:{prev_output}", provider=provider)
+    output = asyncio.run(
+        run_stage(
+            stage, "task", "a" * 100, str(tmp_path), limits=Limits(prev_output_chars=10)
+        )
+    )
+    assert output == "ok"
+    assert provider.prompts == ["PREV:" + "a" * 10]
 
 
 def test_provider_for_timeout_reaches_provider():

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.config import Limits, resolve_limits, resolve_pipeline
+from app.config import Limits, provider_for, resolve_limits, resolve_pipeline
 
 
 def test_defaults_when_section_absent():
@@ -58,6 +58,17 @@ def test_default_max_iterations_reaches_stage(tmp_path):
     stages = resolve_pipeline(config, str(tmp_path))
     gate = next(stage for stage in stages if stage.kind == "gate")
     assert gate.max_iterations == 5
+
+
+def test_provider_for_timeout_reaches_provider():
+    provider = provider_for("claude", "", timeout_seconds=42)
+    assert provider.timeout_seconds == 42
+
+
+def test_configured_timeout_propagates_through_resolve_pipeline(tmp_path):
+    config = {"limits": {"provider_timeout_seconds": 1200}}
+    stages = resolve_pipeline(config, str(tmp_path))
+    assert all(stage.provider.timeout_seconds == 1200 for stage in stages)
 
 
 def test_explicit_phase_max_iterations_wins_over_default(tmp_path):

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -121,6 +121,29 @@ def test_custom_phase_without_skill_or_prompt_fails(tmp_path, monkeypatch):
         resolve_pipeline(config, str(tmp_path))
 
 
+def test_eval_prompt_on_non_gate_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    config = {"phases": {"Planning": {"eval_prompt": "good? {prev_output}"}}}
+    with pytest.raises(ValueError, match="only 'gate' phases"):
+        resolve_pipeline(config, str(tmp_path))
+
+
+def test_both_eval_skill_and_eval_prompt_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    _write_skill(tmp_path, "judge", "verdict {prev_output}\n")
+    config = {"phases": {"Code Quality": {"eval_skill": "judge", "eval_prompt": "x"}}}
+    with pytest.raises(ValueError, match="both 'eval_skill' and 'eval_prompt'"):
+        resolve_pipeline(config, str(tmp_path))
+
+
+def test_eval_skill_resolves_into_gate_stage(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    _write_skill(tmp_path, "judge", "verdict {prev_output}\n")
+    config = {"phases": {"Code Quality": {"eval_skill": "judge"}}}
+    stages = {s.name: s for s in resolve_pipeline(config, str(tmp_path))}
+    assert stages["Code Quality"].eval_prompt_template == "verdict {prev_output}\n"
+
+
 def test_leftover_table_for_dropped_phase_is_ignored(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
     config = {

--- a/tests/test_provider_flags.py
+++ b/tests/test_provider_flags.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app.config import resolve_pipeline
 from app.providers.claude import ClaudeProvider
 from app.providers.codex import CodexProvider
 from app.providers.gemini import GeminiProvider
@@ -35,3 +36,18 @@ def test_extra_args_appended_last(provider_cls):
 
 def test_codex_keeps_exec_dash_positional():
     assert CodexProvider()._build_cmd()[:4] == ["codex", "exec", "-", "--json"]
+
+
+def test_phase_skip_permissions_false_reaches_stage_provider(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    config = {"phases": {"Code Quality": {"skip_permissions": False}}}
+    stages = {s.name: s for s in resolve_pipeline(config, str(tmp_path))}
+    assert stages["Code Quality"].provider.skip_permissions is False
+    assert stages["Planning"].provider.skip_permissions is True
+
+
+def test_extra_args_must_be_list_of_strings(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    config = {"defaults": {"extra_args": "nope"}}
+    with pytest.raises(ValueError, match="extra_args must be a list of strings"):
+        resolve_pipeline(config, str(tmp_path))

--- a/tests/test_provider_flags.py
+++ b/tests/test_provider_flags.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app.providers.claude import ClaudeProvider
+from app.providers.codex import CodexProvider
+from app.providers.gemini import GeminiProvider
+
+DANGER_FLAGS = {
+    ClaudeProvider: "--dangerously-skip-permissions",
+    CodexProvider: "--dangerously-bypass-approvals-and-sandbox",
+    GeminiProvider: "--yolo",
+}
+
+
+def _build(provider):
+    if isinstance(provider, GeminiProvider):
+        return provider._build_cmd("hi")
+    return provider._build_cmd()
+
+
+@pytest.mark.parametrize("provider_cls", [ClaudeProvider, CodexProvider, GeminiProvider])
+def test_danger_flag_present_by_default(provider_cls):
+    assert DANGER_FLAGS[provider_cls] in _build(provider_cls())
+
+
+@pytest.mark.parametrize("provider_cls", [ClaudeProvider, CodexProvider, GeminiProvider])
+def test_danger_flag_omitted_when_skip_permissions_false(provider_cls):
+    assert DANGER_FLAGS[provider_cls] not in _build(provider_cls(skip_permissions=False))
+
+
+@pytest.mark.parametrize("provider_cls", [ClaudeProvider, CodexProvider, GeminiProvider])
+def test_extra_args_appended_last(provider_cls):
+    cmd = _build(provider_cls(model="m", extra_args=("--flag-a", "value")))
+    assert cmd[-2:] == ["--flag-a", "value"]
+
+
+def test_codex_keeps_exec_dash_positional():
+    assert CodexProvider()._build_cmd()[:4] == ["codex", "exec", "-", "--json"]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.models import PipelineStats
+from app.models import PipelineStats, cost_cap_exceeded
 
 
 def test_add_call_accumulates_known_cost_and_counts_none():
@@ -29,3 +29,20 @@ def test_reset_clears_calls_without_cost():
     stats.reset()
     assert stats.calls_without_cost == 0
     assert stats.format_cost() == "$0.0000"
+
+
+def test_cost_cap_exceeded_never_trips_without_cap():
+    stats = PipelineStats()
+    stats.add_call(999.0)
+    assert cost_cap_exceeded(stats, None) is False
+
+
+def test_cost_cap_exceeded_trips_at_and_above_cap():
+    stats = PipelineStats()
+    assert cost_cap_exceeded(stats, 1.0) is False
+    stats.add_call(0.5)
+    assert cost_cap_exceeded(stats, 1.0) is False
+    stats.add_call(0.5)
+    assert cost_cap_exceeded(stats, 1.0) is True
+    stats.add_call(0.1)
+    assert cost_cap_exceeded(stats, 1.0) is True

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.models import PipelineStats, cost_cap_exceeded
+from app.models import PipelineStats, Task, cost_cap_exceeded, filter_tasks
 
 
 def test_add_call_accumulates_known_cost_and_counts_none():
@@ -29,6 +29,12 @@ def test_reset_clears_calls_without_cost():
     stats.reset()
     assert stats.calls_without_cost == 0
     assert stats.format_cost() == "$0.0000"
+
+
+def test_filter_tasks_keeps_only_selected_ids_in_order():
+    tasks = [Task(id=1, description="a"), Task(id=2, description="b"), Task(id=3, description="c")]
+    assert [task.id for task in filter_tasks(tasks, [3, 1])] == [1, 3]
+    assert filter_tasks(tasks, []) == []
 
 
 def test_cost_cap_exceeded_never_trips_without_cap():

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,12 @@
+import json
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def test_pyproject_and_npm_versions_match():
+    with open(REPO_ROOT / "pyproject.toml", "rb") as handle:
+        python_version = tomllib.load(handle)["project"]["version"]
+    npm_version = json.loads((REPO_ROOT / "npm" / "package.json").read_text())["version"]
+    assert python_version == npm_version

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "step-by-step-cli"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "psutil" },


### PR DESCRIPTION
## What

User-facing customization and checkability for 0.2.0, all through the existing TOML config and CLI flags — no code edits needed on installed packages.

- **`[limits]`** — provider timeout, RAM threshold, context-truncation sizes, default gate iterations. Unknown keys or out-of-range values abort before the run.
- **Cost cap** — `max_cost_usd` stops the run at the next stage boundary; each stage log line shows its cost delta.
- **`pipeline --check`** — config dry-run: prints resolved pipeline, effective limits, and provider preflight without calling any LLM.
- **`[confirm]` checkpoints** — pause before listed phases (Commit & PR shows `git status`/`diff --stat`), checkbox review of decomposed subtasks, and step mode (`--step`) pausing after every stage.
- **`[artifacts]`** — per-run directory with prompt, every stage output (gate re-runs keep each attempt), and `run.json` with a tri-state outcome (completed/failed/stopped).
- **Prompt overrides** — Decomposition accepts `skill`/`prompt`; the quality-gate evaluator accepts `eval_prompt`/`eval_skill`.
- **Provider flags** — `skip_permissions = false` omits the danger flags; `extra_args` appends raw CLI arguments. Both per-phase or in `[defaults]`.
- **Ctrl+X** cancels the running pipeline, leaving every stage re-runnable.
- Final status distinguishes intentional stops (`⏹ Stopped`) from failures (`✗ Failed`).

## Compatibility

With no new config keys, behavior is identical to 0.1.x: every new default equals the previous hardcoded value; confirmations and artifacts are off by default. Verified by building the 0.2.0 wheel and smoke-testing `pipeline --help` / `--check` in a clean venv.

## Testing

- 101 tests (43 on main), ruff clean, `uv sync --locked` green.
- Known limitation (documented): a parallel fan-out can overshoot `max_cost_usd` before the next stage-boundary check.