### PR TITLE
ci: PyPI release workflow on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: echo "version=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if this version is already released
+        id: released
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.released.outputs.exists == 'false'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Test
+        if: steps.released.outputs.exists == 'false'
+        run: |
+          uv sync --locked
+          uv run pytest
+
+      - name: Build
+        if: steps.released.outputs.exists == 'false'
+        run: uv build
+
+      - name: Publish to PyPI
+        if: steps.released.outputs.exists == 'false'
+        run: uv publish --token "${{ secrets.PYPI_API_TOKEN }}" --check-url https://pypi.org/simple/
+
+      - name: Extract changelog section for release notes
+        if: steps.released.outputs.exists == 'false'
+        run: |
+          awk '/^## \[${{ steps.version.outputs.version }}\]/{found=1; next} /^## \[/{found=0} found' CHANGELOG.md > release-notes.md
+          if ! [ -s release-notes.md ]; then
+            echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md)." > release-notes.md
+          fi
+
+      - name: Create GitHub Release
+        if: steps.released.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes-file release-notes.md \
+            dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Per-provider autonomy flags** — `skip_permissions = false` omits `--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox` / `--yolo`, and `extra_args` appends raw CLI arguments; both in `[defaults]` or per phase.
 - **Ctrl+X** cancels the running pipeline, killing provider subprocesses and leaving every stage re-runnable.
 - **CI** — GitHub Actions runs the test suite on every push to `main` and every pull request (#21).
+- **CD** — a push to `main` with a new `version` in `pyproject.toml` (major, minor, or patch) runs the tests, publishes to PyPI, and creates the matching `vX.Y.Z` GitHub Release with that version's changelog section as notes.
 
 ### Changed
 


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml`: on every push to `main`, if `pyproject.toml`'s version (major, minor, or patch bump) has no matching `vX.Y.Z` GitHub Release yet, the workflow runs the test suite, builds with `uv build`, publishes to PyPI (`PYPI_API_TOKEN` repo secret, project-scoped), and creates the GitHub Release with that version's CHANGELOG section as notes and the dist artifacts attached.

Idempotent: when the current version already has a release, the run is a no-op (`--check-url` additionally makes a re-publish after a partial failure safe). Actions are SHA-pinned, matching `ci.yml`.

## Note

Merging this publishes 0.2.0: main is already at version 0.2.0 with no `v0.2.0` release, so the first run on main will release it.