### PR TITLE
chore: CODEOWNERS and CI on dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ValentinDutra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 permissions:


### PR DESCRIPTION
Prepares the branch-protection setup: `.github/CODEOWNERS` makes @ValentinDutra the required reviewer for everything, and CI now also runs on direct pushes to `dev` (the new default working branch).